### PR TITLE
[SAGE-788] Bug Fix: RabbitMQ user wiped on reboot

### DIFF
--- a/kubernetes/data-sharing-service.yaml
+++ b/kubernetes/data-sharing-service.yaml
@@ -26,12 +26,12 @@ spec:
           valueFrom:
             secretKeyRef:
               name: wes-rabbitmq-service-account-secret
-              key: USERNAME
+              key: username
         - name: RABBITMQ_PASSWORD
           valueFrom:
             secretKeyRef:
               name: wes-rabbitmq-service-account-secret
-              key: PASSWORD
+              key: password
         resources:
           limits:
             cpu: 200m

--- a/kubernetes/delete-stack.sh
+++ b/kubernetes/delete-stack.sh
@@ -11,4 +11,3 @@ kubectl delete -f node-exporter.yaml
 # delete config and secrets
 kubectl delete configmap waggle-config
 kubectl delete secret waggle-secret
-kubectl delete secret wes-rabbitmq-service-account-secret

--- a/kubernetes/deploy-stack.sh
+++ b/kubernetes/deploy-stack.sh
@@ -59,7 +59,7 @@ kubectl apply -f wes-rabbitmq.yaml
 
 echo "generating rabbitmq service account credentials"
 ./update-rabbitmq-auth.sh wes-rabbitmq-service-account-secret service '.*' '.*' '.*'
-./update-rabbitmq-auth.sh wes-rabbitmq-shovel-account-secret service '^$' '^$' '^to-beehive|to-beekeeper$'
+./update-rabbitmq-auth.sh wes-rabbitmq-shovel-account-secret shovel '^$' '^$' '^to-beehive|to-beekeeper$'
 
 (kubectl delete secret waggle-ssh-key-secret || true) &>/dev/null
 if ls /etc/waggle/ssh-key /etc/waggle/ssh-key.pub /etc/waggle/ssh-key-cert.pub; then

--- a/kubernetes/shovelctl.sh
+++ b/kubernetes/shovelctl.sh
@@ -1,11 +1,18 @@
 #!/bin/bash -e
 
+rmqctl() {
+  kubectl exec svc/wes-rabbitmq -- rabbitmqctl -q "$@"
+}
+
 enable_shovels() {
     nodeID=$(kubectl get cm waggle-config --template={{.data.WAGGLE_NODE_ID}})
     beehive_host=$(kubectl get cm waggle-config --template={{.data.WAGGLE_BEEHIVE_RABBITMQ_HOST}})
     beehive_port=$(kubectl get cm waggle-config --template={{.data.WAGGLE_BEEHIVE_RABBITMQ_PORT}})
-    kubectl exec -i svc/wes-rabbitmq -- rabbitmqctl set_parameter shovel push-messages "{
-  \"src-uri\": \"amqp://shovel:shovel@wes-rabbitmq\",
+    username=$(kubectl get secret wes-rabbitmq-shovel-account-secret --template={{.data.username}} | base64 -d)
+    password=$(kubectl get secret wes-rabbitmq-shovel-account-secret --template={{.data.password}} | base64 -d)
+
+    while ! rmqctl set_parameter shovel push-messages "{
+  \"src-uri\": \"amqp://${username}:${password}@wes-rabbitmq\",
   \"src-queue\": \"to-beehive\",
   \"dest-uri\": \"amqps://${beehive_host}:${beehive_port}?auth_mechanism=external&cacertfile=/etc/ca/cacert.pem&certfile=/etc/tls/cert.pem&keyfile=/etc/tls/key.pem\",
   \"dest-exchange\": \"waggle.msg\",
@@ -14,15 +21,19 @@ enable_shovels() {
     \"user_id\": \"node-$nodeID\"
   }
 }
-"
+"; do
+    sleep 3
+  done
 }
 
 disable_shovels() {
-    kubectl exec -i svc/wes-rabbitmq -- rabbitmqctl clear_parameter shovel push-messages
+    while ! rmqctl clear_parameter shovel push-messages; do
+      sleep 3
+    done
 }
 
 case "$1" in
-enable) enable_shovels ;;
-disable) disable_shovels ;;
+start|enable) enable_shovels ;;
+stop|disable) disable_shovels ;;
 *) echo "usage: $0 (enable|disable)"; exit 1 ;;
 esac

--- a/kubernetes/update-rabbitmq-auth.sh
+++ b/kubernetes/update-rabbitmq-auth.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+rmqctl() {
+    kubectl exec svc/wes-rabbitmq -- rabbitmqctl "$@"
+}
+
+secretname="$1"
+username="$2"
+confperm="$3"
+writeperm="$4"
+readperm="$5"
+tags="$6"
+password="$(openssl rand -hex 20)"
+
+echo "updating kubernetes config ${secretname}..."
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${secretname}
+type: kubernetes.io/basic-auth
+stringData:
+  username: ${username}
+  password: ${password}
+EOF
+
+echo "updating rabbitmq user ${username}..."
+(
+while ! rmqctl authenticate_user "$username" "$password"; do
+    while ! (rmqctl add_user "$username" "$password" || rmqctl change_password "$username" "$password"); do
+      sleep 3
+    done
+done
+
+while ! rmqctl set_permissions "$username" "$confperm" "$writeperm" "$readperm"; do
+  sleep 3
+done
+
+while ! rmqctl set_user_tags "$username" "$tags"; do
+  sleep 3
+done
+) &> /dev/null
+echo "done"

--- a/kubernetes/wes-metrics-agent.yaml
+++ b/kubernetes/wes-metrics-agent.yaml
@@ -40,12 +40,12 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: wes-rabbitmq-service-account-secret
-                key: USERNAME
+                key: username
           - name: RABBITMQ_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: wes-rabbitmq-service-account-secret
-                key: PASSWORD
+                key: password
           - name: METRICS_URL
             value: "http://$(HOST_IP):9100/metrics"
           - name: RABBITMQ_EXCHANGE

--- a/kubernetes/wes-rabbitmq.yaml
+++ b/kubernetes/wes-rabbitmq.yaml
@@ -41,16 +41,6 @@ data:
                 "tags": "administrator"
             },
             {
-                "name": "service",
-                "password": "service",
-                "tags": ""
-            },
-            {
-                "name": "shovel",
-                "password": "shovel",
-                "tags": ""
-            },
-            {
                 "name": "plugin",
                 "password": "plugin",
                 "tags": ""
@@ -68,20 +58,6 @@ data:
                 "configure": ".*",
                 "write": ".*",
                 "read": ".*"
-            },
-            {
-                "user": "service",
-                "vhost": "/",
-                "configure": ".*",
-                "write": ".*",
-                "read": ".*"
-            },
-            {
-                "user": "shovel",
-                "vhost": "/",
-                "configure": "^$",
-                "write": "^$",
-                "read": "to-beehive|to-beekeeper"
             },
             {
                 "user": "plugin",

--- a/kubernetes/wes-rabbitmq.yaml
+++ b/kubernetes/wes-rabbitmq.yaml
@@ -215,6 +215,8 @@ spec:
         - name: beehive-rabbitmq-tls
           mountPath: /etc/tls
           readOnly: true
+        - name: data
+          mountPath: /var/lib/rabbitmq
       volumes:
       - name: config
         configMap:
@@ -227,3 +229,11 @@ spec:
         secret:
           secretName: wes-beehive-rabbitmq-tls
           optional: true
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi


### PR DESCRIPTION
To address this, I made the following changes:
* Added a persistent volume to RabbitMQ.
* Removed service and shovel user from definitions.json config to prevent passwords from being reset on boot.
* Generate service and shovel RabbitMQ auth as part of the deploy script.
* Added script to add / refresh these credentials, if needed.