### PR TITLE
[Sage-800] Add support for metrics data dir

### DIFF
--- a/kubernetes/wes-metrics-agent.yaml
+++ b/kubernetes/wes-metrics-agent.yaml
@@ -62,6 +62,9 @@ spec:
           mountPropagation: HostToContainer
           name: etc
           readOnly: true
+        - mountPath: /run/metrics
+          mountPropagation: HostToContainer
+          name: metrics-data-dir
       volumes:
       - hostPath:
           path: /proc
@@ -69,3 +72,6 @@ spec:
       - hostPath:
           path: /etc
         name: etc
+      - hostPath:
+          path: /run/metrics
+        name: metrics-data-dir

--- a/kubernetes/wes-metrics-agent.yaml
+++ b/kubernetes/wes-metrics-agent.yaml
@@ -58,7 +58,14 @@ spec:
           mountPropagation: HostToContainer
           name: proc
           readOnly: true
+        - mountPath: /host/etc
+          mountPropagation: HostToContainer
+          name: etc
+          readOnly: true
       volumes:
       - hostPath:
           path: /proc
         name: proc
+      - hostPath:
+          path: /etc
+        name: etc

--- a/services/wes-metrics-agent/Dockerfile
+++ b/services/wes-metrics-agent/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.8-alpine
+RUN apk add --no-cache iproute2
 COPY requirements.txt requirements.txt
 RUN pip3 install --no-cache-dir -r requirements.txt
 COPY . .

--- a/services/wes-metrics-agent/main.py
+++ b/services/wes-metrics-agent/main.py
@@ -18,7 +18,7 @@ def get_node_exporter_metrics(url):
 
 
 def get_uptime_seconds():
-    text = Path("/proc/uptime").read_text()
+    text = Path("/host/proc/uptime").read_text()
     fs = text.split()
     return float(fs[0])
 
@@ -84,7 +84,7 @@ def add_version_metrics(args, messages):
     logging.info("collecting version metrics")
 
     try:
-        version = Path("/etc/waggle_version_os").read_text().strip()
+        version = Path("/host/etc/waggle_version_os").read_text().strip()
         messages.append(message.Message(
             name="sys.version.os",
             value=version,
@@ -95,7 +95,7 @@ def add_version_metrics(args, messages):
         pass
 
     try:
-        version = Path("/etc/waggle_version_provision").read_text().strip()
+        version = Path("/host/etc/waggle_version_provision").read_text().strip()
         messages.append(message.Message(
             name="sys.version.provision",
             value=version,

--- a/services/wes-metrics-agent/main.py
+++ b/services/wes-metrics-agent/main.py
@@ -104,20 +104,6 @@ def add_version_metrics(args, messages):
     except Exception:
         logging.exception("failed to get os version")
 
-    try:
-        version = Path("/host/etc/waggle_version_provision").read_text().strip()
-        messages.append(message.Message(
-            name="sys.version.provision",
-            value=version,
-            timestamp=timestamp,
-            meta={},
-        ))
-        logging.info("added provision version")
-    except FileNotFoundError:
-        logging.info("provision version not found. skipping...")
-    except Exception:
-        logging.exception("failed to get provision version")
-
 
 def flush_messages_to_rabbitmq(args, messages):
     if len(messages) == 0:

--- a/services/wes-metrics-agent/main.py
+++ b/services/wes-metrics-agent/main.py
@@ -156,7 +156,7 @@ def flush_messages_to_rabbitmq(args, messages):
                 messages.popleft()
                 published_total += 1
     except Exception:
-        logging.warning("rabbitmq connection failed. will resume next round")
+        logging.warning("rabbitmq connection failed. %d metrics buffered for retry", len(messages))
 
     logging.info("published %d metrics", published_total)
 

--- a/services/wes-metrics-agent/main.py
+++ b/services/wes-metrics-agent/main.py
@@ -91,8 +91,10 @@ def add_version_metrics(args, messages):
             meta={},
         ))
         logging.info("added os version")
+    except FileNotFoundError:
+        logging.info("os version not found. skipping...")
     except Exception:
-        pass
+        logging.exception("failed to get os version")
 
     try:
         version = Path("/host/etc/waggle_version_provision").read_text().strip()
@@ -102,8 +104,10 @@ def add_version_metrics(args, messages):
             meta={},
         ))
         logging.info("added provision version")
+    except FileNotFoundError:
+        logging.info("provision version not found. skipping...")
     except Exception:
-        pass
+        logging.exception("failed to get provision version")
 
 
 def flush_messages_to_rabbitmq(args, messages):

--- a/services/wes-metrics-agent/main.py
+++ b/services/wes-metrics-agent/main.py
@@ -73,21 +73,29 @@ def add_system_metrics(args, messages):
 
 def add_uptime_metrics(args, messages):
     logging.info("collecting uptime metrics")
-    messages.append(message.Message(
-        name="sys.uptime",
-        value=get_uptime_seconds(),
-        meta={},
-    ))
+    timestamp = time.time_ns()
+    try:
+        uptime = get_uptime_seconds()
+        messages.append(message.Message(
+            name="sys.uptime",
+            value=uptime,
+            timestamp=timestamp,
+            meta={},
+        ))
+    except Exception:
+        logging.exception("failed to get uptime")
 
 
 def add_version_metrics(args, messages):
     logging.info("collecting version metrics")
+    timestamp = time.time_ns()
 
     try:
         version = Path("/host/etc/waggle_version_os").read_text().strip()
         messages.append(message.Message(
             name="sys.version.os",
             value=version,
+            timestamp=timestamp,
             meta={},
         ))
         logging.info("added os version")
@@ -101,6 +109,7 @@ def add_version_metrics(args, messages):
         messages.append(message.Message(
             name="sys.version.provision",
             value=version,
+            timestamp=timestamp,
             meta={},
         ))
         logging.info("added provision version")


### PR DESCRIPTION
I've added support for scraping a metrics data directory defined by the [waggle-publish-metric](https://github.com/waggle-sensor/waggle-common-tools/blob/main/ROOTFS/usr/bin/waggle-publish-metric) tool.

Metrics will be scraped from a metrics data dir, cleaned up and cached in RabbitMQ and shipped alongside other system metrics.