### PR TITLE
[SAGE-1007] Updated data sharing service to tag device metadata.

### DIFF
--- a/kubernetes/wes-data-sharing-service.yaml
+++ b/kubernetes/wes-data-sharing-service.yaml
@@ -17,7 +17,7 @@ spec:
         node-role.kubernetes.io/master: "true"
       containers:
       - name: wes-data-sharing-service
-        image: waggle/wes-data-sharing-service:0.3.1
+        image: waggle/wes-data-sharing-service:0.3.2
         envFrom:
         - configMapRef:
             name: waggle-config

--- a/kubernetes/wes-data-sharing-service.yaml
+++ b/kubernetes/wes-data-sharing-service.yaml
@@ -45,22 +45,13 @@ spec:
             memory: 10Mi
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: wes-data-sharing-service-svc-cluster-role
-rules:
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get", "watch", "list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: wes-data-sharing-service-svc-account-read
   namespace: default
 roleRef:
   kind: ClusterRole
-  name: wes-data-sharing-service-svc-cluster-role
+  name: view
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount

--- a/kubernetes/wes-data-sharing-service.yaml
+++ b/kubernetes/wes-data-sharing-service.yaml
@@ -52,7 +52,7 @@ metadata:
   namespace: default
 roleRef:
   kind: ClusterRole
-  name: read
+  name: view
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount

--- a/kubernetes/wes-data-sharing-service.yaml
+++ b/kubernetes/wes-data-sharing-service.yaml
@@ -44,7 +44,15 @@ spec:
             cpu: 100m
             memory: 10Mi
 ---
-# wes-data-sharing svc must be able to *read* Pod metadata.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: wes-data-sharing-service-svc-cluster-role
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -52,7 +60,7 @@ metadata:
   namespace: default
 roleRef:
   kind: ClusterRole
-  name: view
+  name: wes-data-sharing-service-svc-cluster-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount

--- a/kubernetes/wes-data-sharing-service.yaml
+++ b/kubernetes/wes-data-sharing-service.yaml
@@ -11,12 +11,13 @@ spec:
       labels:
         app: wes-data-sharing-service
     spec:
+      serviceAccountName: wes-data-sharing-service-svc-account
       priorityClassName: wes-high-priority
       nodeSelector:
         node-role.kubernetes.io/master: "true"
       containers:
       - name: wes-data-sharing-service
-        image: waggle/wes-data-sharing-service:0.2.1
+        image: waggle/wes-data-sharing-service:0.3.1
         envFrom:
         - configMapRef:
             name: waggle-config
@@ -42,4 +43,23 @@ spec:
           requests:
             cpu: 100m
             memory: 10Mi
-
+---
+# wes-data-sharing svc must be able to *read* Pod metadata.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: wes-data-sharing-service-svc-account-read
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: read
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: wes-data-sharing-service-svc-account
+  namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: wes-data-sharing-service-svc-account


### PR DESCRIPTION
This PR updates wes-data-sharing service to version 0.3.2. The service also uses the view role to get Pod metadata.