### PR TITLE
[Sage-1208] Improved wes-camera-provisioner logic

### DIFF
--- a/kubernetes/wes-camera-provisioner.yaml
+++ b/kubernetes/wes-camera-provisioner.yaml
@@ -53,9 +53,10 @@ spec:
           restartPolicy: Never
           serviceAccountName: wes-camera-provisioner-svc-account
           priorityClassName: wes-high-priority
+          hostNetwork: true
           containers:
           - name: wes-camera-provisioner
-            image: waggle/wes-camera-provisioner:0.0.4
+            image: waggle/wes-camera-provisioner:0.0.5
             resources:
               limits:
                 cpu: 200m


### PR DESCRIPTION
`wes-camera-provisioner` now uses nmap to get list of cameras along with port information from Unifi network switch.