### PR TITLE
[Sage-1215] Sending scheduling decision to Beehive

### DIFF
--- a/kubernetes/wes-plugin-scheduler.yaml
+++ b/kubernetes/wes-plugin-scheduler.yaml
@@ -15,8 +15,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wes-plugin-scheduler
-  labels:
-    sagecontinuum.org/plugin-task: scheduler
 spec:
   selector:
     matchLabels:
@@ -25,6 +23,7 @@ spec:
     metadata:
       labels:
         app: wes-plugin-scheduler
+        sagecontinuum.org/plugin-task: scheduler
     spec:
       priorityClassName: wes-high-priority
       serviceAccountName: wes-plugin-scheduler

--- a/kubernetes/wes-plugin-scheduler.yaml
+++ b/kubernetes/wes-plugin-scheduler.yaml
@@ -15,6 +15,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wes-plugin-scheduler
+  labels:
+    sagecontinuum.org/plugin-task: scheduler
 spec:
   selector:
     matchLabels:
@@ -27,7 +29,7 @@ spec:
       priorityClassName: wes-high-priority
       serviceAccountName: wes-plugin-scheduler
       containers:
-      - image: waggle/scheduler:0.9.1
+      - image: waggle/scheduler:0.9.2
         name: wes-plugin-scheduler
         command: ["/app/nodescheduler"]
         args:
@@ -35,6 +37,11 @@ spec:
         envFrom:
         - configMapRef:
             name: wes-identity
+        env:
+        - name: WAGGLE_APP_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
`wes-plugin-scheduler` now uses Waggle data pipeline to report scheduling decisions to Beehive. To use the pipeline, we added the plugin-task label and APP ID.