### PR TITLE
[Sage-1234] Updated data sharing service permissions to allow scanning pods from all namespaces.

### DIFF
--- a/kubernetes/wes-data-sharing-service.yaml
+++ b/kubernetes/wes-data-sharing-service.yaml
@@ -1,3 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: wes-pod-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: wes-data-sharing-service-svc-account
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: wes-data-sharing-service-svc-account-read
+roleRef:
+  kind: ClusterRole
+  name: wes-pod-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: wes-data-sharing-service-svc-account
+    namespace: default
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,26 +60,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 20Mi
+              memory: 80Mi
             requests:
               cpu: 100m
-              memory: 10Mi
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: wes-data-sharing-service-svc-account-read
-  namespace: default
-roleRef:
-  kind: ClusterRole
-  name: view
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-  - kind: ServiceAccount
-    name: wes-data-sharing-service-svc-account
-    namespace: default
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: wes-data-sharing-service-svc-account
+              memory: 40Mi


### PR DESCRIPTION
This PR updates the permissions used by the wes-data-sharing-service to be a cluster role and role binding to allow scanning pods across all namespaces.