### PR TITLE
A quick fix; without delete permission SES and the system go crazy

### DIFF
--- a/kubernetes/wes-plugin-scheduler.yaml
+++ b/kubernetes/wes-plugin-scheduler.yaml
@@ -57,7 +57,7 @@ metadata:
 rules:
   - apiGroups: ["", "batch"] # "" indicates the core API group
     resources: ["namespaces", "configmaps", "services", "jobs", "nodes", "pods"]
-    verbs: ["create", "get", "watch", "list", "update", "patch"]
+    verbs: ["create", "get", "watch", "list", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
The SES could not delete complete plugins because it lacked the delete permission to clean up the plugins. This made the SES created +1000 Kubernetes jobs/pods.

We also observed that the system was so busy (see the load averages). I believe this is related to the number of uncleaned pods.
```bash
root@ws-nxcore-000048B02D3AE313:~# uptime
 02:27:41 up 4 days,  6:27,  1 user,  load average: 14.98, 11.92, 11.06
```