### PR TITLE
Adding node-influxdb, its loader, and simple scoreboard

### DIFF
--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -81,6 +81,7 @@ setup_influxdb() {
     kubectl exec svc/wes-node-influxdb -- influx setup \
         --org waggle \
         --bucket waggle \
+        --retention 604800 \ # 1 week
         --username waggle \
         --password wagglewaggle \
         --force
@@ -341,6 +342,8 @@ EOF
     kubectl get secret wes-beehive-upload-ssh-key -o jsonpath='{.data.ssh-key\.pub}' | base64 -d > configs/upload-agent/ssh-key.pub
 
     # create or pull influxdb token
+    echo "setting influxdb..."
+    # it is assumed that the commands below may fail.
     set +e
     setup_influxdb
     WAGGLE_INFLUXDB_TOKEN=$(kubectl exec svc/wes-node-influxdb -- influx auth ls | grep waggle-write-token | awk '{ print $3 }')

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -347,10 +347,11 @@ EOF
     # it is assumed that the commands below may fail.
     set +e
     setup_influxdb
-    WAGGLE_INFLUXDB_TOKEN=$(kubectl exec svc/wes-node-influxdb -- influx auth ls | grep waggle-write-token | awk '{ print $3 }')
+    TOKEN_NAME="waggle-read-write-bucket"
+    WAGGLE_INFLUXDB_TOKEN=$(kubectl exec svc/wes-node-influxdb -- influx auth ls | grep ${TOKEN_NAME} | awk '{ print $3 }')
     if [ "${WAGGLE_INFLUXDB_TOKEN}x" == "x" ]; then
         echo "creating influxdb token..."
-        WAGGLE_INFLUXDB_TOKEN=$(kubectl exec svc/wes-node-influxdb -- influx auth create -u waggle -o waggle --hide-headers --write-buckets -d waggle-write-token | awk '{ print $3 }')
+        WAGGLE_INFLUXDB_TOKEN=$(kubectl exec svc/wes-node-influxdb -- influx auth create -u waggle -o waggle --hide-headers --read-buckets --write-buckets -d $TOKEN_NAME | awk '{ print $3 }')
     else
         echo "token found. skipping creating influxdb token"
     fi

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -82,7 +82,7 @@ setup_influxdb() {
     kubectl exec svc/wes-node-influxdb -- influx setup \
         --org waggle \
         --bucket waggle \
-        --retention 604800 \
+        --retention 7d \
         --username waggle \
         --password wagglewaggle \
         --force

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -425,6 +425,7 @@ resources:
   - wes-upload-agent.yaml
   - wes-metrics-agent.yaml
   - wes-plugin-scheduler.yaml
+  - wes-sciencerule-checker.yaml
   - wes-gps-server.yaml
   - wes-scoreboard.yaml
   - wes-camera-provisioner.yaml

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -78,10 +78,11 @@ update_data_config() {
 }
 
 setup_influxdb() {
+    # retention time set to 1 week
     kubectl exec svc/wes-node-influxdb -- influx setup \
         --org waggle \
         --bucket waggle \
-        --retention 604800 \ # 1 week
+        --retention 604800 \
         --username waggle \
         --password wagglewaggle \
         --force
@@ -350,6 +351,8 @@ EOF
     if [ "${WAGGLE_INFLUXDB_TOKEN}x" == "x" ]; then
         echo "creating influxdb token..."
         WAGGLE_INFLUXDB_TOKEN=$(kubectl exec svc/wes-node-influxdb -- influx auth create -u waggle -o waggle --hide-headers --write-buckets -d waggle-write-token | awk '{ print $3 }')
+    else
+        echo "token found. skipping creating influxdb token"
     fi
     set -e
 

--- a/kubernetes/wes-kubernetes-monitoring-agent.yaml
+++ b/kubernetes/wes-kubernetes-monitoring-agent.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: wes-kubernetes-monitoring-agent
+  labels:
+    app.kubernetes.io/name: wes-kubernetes-monitoring-agent
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: wes-kubernetes-monitoring-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: wes-kubernetes-monitoring-agent
+    spec:
+      priorityClassName: wes-high-priority
+      containers:
+        - image: telegraf:1.21.2-alpine
+          name: wes-kubernetes-monitoring-agent
+          resources:
+            limits:
+              cpu: 200m
+              memory: 60Mi
+            requests:
+              cpu: 100m
+              memory: 30Mi
+          env:
+            - name: WAGGLE_HOST_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: RABBITMQ_HOST
+              value: "wes-rabbitmq"
+            - name: RABBITMQ_PORT
+              value: "5672"
+            - name: RABBITMQ_USERNAME
+              value: service
+            - name: RABBITMQ_PASSWORD
+              value: service
+            - name: METRICS_URL
+              value: "http://$(HOST_IP):9100/metrics"
+            - name: RABBITMQ_EXCHANGE
+              value: "to-beehive"
+            - name: GPSD_HOST
+              value: "wes-gps-server"
+            - name: GPSD_PORT
+              value: "2947"
+          envFrom:
+            - configMapRef:
+                name: wes-identity
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              mountPropagation: HostToContainer
+              readOnly: true
+            - name: etc
+              mountPath: /host/etc
+              mountPropagation: HostToContainer
+              readOnly: true
+            - name: metrics-data-dir
+              mountPath: /run/metrics
+              mountPropagation: HostToContainer
+            - name: sys-kernel-debug
+              mountPath: /sys/kernel/debug
+              mountPropagation: HostToContainer
+              readOnly: true
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: etc
+          hostPath:
+            path: /etc
+        - name: metrics-data-dir
+          hostPath:
+            path: /run/metrics
+        # required for gpu information to be read
+        - name: sys-kernel-debug
+          hostPath:
+            path: /sys/kernel/debug

--- a/kubernetes/wes-node-influxdb-loader.yaml
+++ b/kubernetes/wes-node-influxdb-loader.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wes-node-influxdb-loader
+spec:
+  selector:
+    matchLabels:
+      app: wes-node-influxdb-loader
+  template:
+    metadata:
+      labels:
+        app: wes-node-influxdb-loader
+    spec:
+      priorityClassName: wes-high-priority
+      containers:
+      - image: waggle/node-influxdb-loader:0.0.0
+        name: wes-node-influxdb-loader
+        resources:
+          limits:
+            cpu: 100m
+            memory: 150Mi
+          requests:
+            cpu: 50m
+            memory: 100Mi
+        ports:
+        - name: metrics
+          containerPort: 8080
+        env:
+        - name: RABBITMQ_HOST
+          value: "wes-rabbitmq"
+        - name: RABBITMQ_PORT
+          value: "5672"
+        - name: RABBITMQ_USERNAME
+          value: "service"
+        - name: RABBITMQ_PASSWORD
+          value: "service"
+        - name: RABBITMQ_EXCHANGE
+          value: "data.topic"
+        - name: INFLUXDB_URL
+          value: "http://wes-node-influxdb:8086"
+        - name: INFLUXDB_BUCKET
+          value: "waggle"
+        - name: INFLUXDB_ORG
+          value: "waggle"
+        - name: INFLUXDB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: wes-node-influxdb-waggle-token
+              key: token

--- a/kubernetes/wes-node-influxdb.yaml
+++ b/kubernetes/wes-node-influxdb.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: wes-node-influxdb
+spec:
+    ports:
+      - name: wes-node-influxdb
+        port: 8086
+        targetPort: 8086
+    selector:
+        app: wes-node-influxdb
+    type: ClusterIP
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+    labels:
+        app: wes-node-influxdb
+    name: wes-node-influxdb
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: wes-node-influxdb
+    serviceName: wes-node-influxdb
+    template:
+      metadata:
+          labels:
+              app: wes-node-influxdb
+      spec:
+        priorityClassName: wes-high-priority
+        nodeSelector:
+          node-role.kubernetes.io/master: "true"
+        containers:
+          - image: influxdb:2.1.1
+            name: wes-node-influxdb
+            resources:
+              limits:
+                cpu: 500m
+                memory: 500Mi
+              requests:
+                cpu: 300m
+                memory: 100Mi
+            ports:
+              - containerPort: 8086
+                name: influxdb
+            volumeMounts:
+              - mountPath: /var/lib/influxdb2
+                name: data
+    volumeClaimTemplates:
+      - metadata:
+            name: data
+        spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+                requests:
+                    storage: 5G

--- a/kubernetes/wes-plugin-scheduler.yaml
+++ b/kubernetes/wes-plugin-scheduler.yaml
@@ -28,9 +28,9 @@ spec:
       priorityClassName: wes-high-priority
       serviceAccountName: wes-plugin-scheduler
       containers:
-      - image: waggle/scheduler:0.9.7
+      - image: waggle/scheduler:0.12.1
         name: wes-plugin-scheduler
-        command: ["/app/nodescheduler"]
+        command: ["nodescheduler"]
         args:
         - -in-cluster
         envFrom:

--- a/kubernetes/wes-plugin-scheduler.yaml
+++ b/kubernetes/wes-plugin-scheduler.yaml
@@ -27,8 +27,10 @@ spec:
     spec:
       priorityClassName: wes-high-priority
       serviceAccountName: wes-plugin-scheduler
+      nodeSelector:
+        node-role.kubernetes.io/master: "true"
       containers:
-      - image: waggle/scheduler:0.12.1
+      - image: waggle/scheduler:0.12.2
         name: wes-plugin-scheduler
         command: ["nodescheduler"]
         args:

--- a/kubernetes/wes-sciencerule-checker.yaml
+++ b/kubernetes/wes-sciencerule-checker.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       priorityClassName: wes-high-priority
       containers:
-      - image: waggle/sciencerule-checker:0.0.1
+      - image: waggle/sciencerule-checker:0.0.2
         name: wes-sciencerule-checker
         env:
         - name: NODE_INFLUXDB_URL

--- a/kubernetes/wes-sciencerule-checker.yaml
+++ b/kubernetes/wes-sciencerule-checker.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       priorityClassName: wes-high-priority
       containers:
-      - image: waggle/sciencerule-checker:0.0.0
+      - image: waggle/sciencerule-checker:0.0.1
         name: wes-sciencerule-checker
         env:
         - name: NODE_INFLUXDB_URL

--- a/kubernetes/wes-sciencerule-checker.yaml
+++ b/kubernetes/wes-sciencerule-checker.yaml
@@ -42,7 +42,7 @@ spec:
         resources:
           limits:
             cpu: 150m
-            memory: 50Mi
+            memory: 150Mi
           requests:
-            cpu: 50m
-            memory: 10Mi
+            cpu: 100m
+            memory: 100Mi

--- a/kubernetes/wes-sciencerule-checker.yaml
+++ b/kubernetes/wes-sciencerule-checker.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: wes-sciencerule-checker
+spec:
+    ports:
+      - name: wes-sciencerule-checker
+        port: 5000
+        targetPort: 5000
+    selector:
+        app: wes-sciencerule-checker
+    type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wes-sciencerule-checker
+spec:
+  selector:
+    matchLabels:
+      app: wes-sciencerule-checker
+  template:
+    metadata:
+      labels:
+        app: wes-sciencerule-checker
+    spec:
+      priorityClassName: wes-high-priority
+      containers:
+      - image: waggle/sciencerule-checker:0.0.0
+        name: wes-sciencerule-checker
+        env:
+        - name: NODE_INFLUXDB_URL
+          value: "http://wes-node-influxdb:8086"
+        - name: NODE_INFLUXDB_QUERY_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: wes-node-influxdb-waggle-token
+              key: token
+        ports:
+        - name: api
+          containerPort: 5000
+        resources:
+          limits:
+            cpu: 150m
+            memory: 50Mi
+          requests:
+            cpu: 50m
+            memory: 10Mi

--- a/kubernetes/wes-scoreboard.yaml
+++ b/kubernetes/wes-scoreboard.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: wes-scoreboard
+spec:
+    ports:
+      - name: wes-scoreboard
+        port: 6379
+        targetPort: 6379
+    selector:
+        app: wes-scoreboard
+    type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wes-scoreboard
+spec:
+  selector:
+    matchLabels:
+      app: wes-scoreboard
+  template:
+    metadata:
+      labels:
+        app: wes-scoreboard
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: "true"
+      priorityClassName: wes-high-priority
+      containers:
+      - image: redis:latest
+        name: wes-scoreboard
+        resources:
+          limits:
+            cpu: 100m
+            memory: 150Mi
+          requests:
+            cpu: 50m
+            memory: 100Mi


### PR DESCRIPTION
node-influxdb and its loaders hold local measurements published by `plugin.publish`.
- 5 GB of storage is allocated from the host system.
- influxdb retention time is set to 7 days. Any data older than 7 days will be dropped by influxDB
- it generates an influx token and registers as Kubernetes Secret.

scoreboard is implemented to enable a quick access to Key/Value database holding data from plugins and scheduler. This is experimental and subject to be removed in any future update.