### PR TITLE
Sage-1439: Add app metadata cache.

### DIFF
--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -455,7 +455,8 @@ EOF
 
     echo "deploying wes stack"
     kubectl apply -k .
-    # TODO(sean) consolidate this into main kustomization instead of one off
+    # NOTE(sean) this is split as its own thing as the version of kubectl (v1.20.2+k3s1) we were using
+    # when this was added didn't seem to support nesting other kustomization dirs as resources.
     kubectl apply -k wes-app-meta-cache
 
     echo "cleaning untagged / broken images"

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -436,7 +436,6 @@ resources:
   - wes-gps-server.yaml
   - wes-scoreboard.yaml
   - wes-camera-provisioner.yaml
-  - wes-app-meta-cache/
 EOF
 
     echo "patching coredns to always run on nxcore"
@@ -456,6 +455,8 @@ EOF
 
     echo "deploying wes stack"
     kubectl apply -k .
+    # TODO(sean) consolidate this into main kustomization instead of one off
+    kubectl apply -k wes-app-meta-cache
 
     echo "cleaning untagged / broken images"
     # wait a moment before checking for images

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -436,6 +436,7 @@ resources:
   - wes-gps-server.yaml
   - wes-scoreboard.yaml
   - wes-camera-provisioner.yaml
+  - wes-app-meta-cache/
 EOF
 
     echo "patching coredns to always run on nxcore"

--- a/kubernetes/wes-app-meta-cache/kustomization.yaml
+++ b/kubernetes/wes-app-meta-cache/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+  - name: wes-app-meta-cache-config
+    files:
+      - redis-config.conf
+resources:
+  - service.yaml
+  - statefulset.yaml

--- a/kubernetes/wes-app-meta-cache/redis-config.conf
+++ b/kubernetes/wes-app-meta-cache/redis-config.conf
@@ -1,0 +1,4 @@
+maxmemory 10mb
+maxmemory-policy allkeys-lru
+timeout 60
+data /data

--- a/kubernetes/wes-app-meta-cache/service.yaml
+++ b/kubernetes/wes-app-meta-cache/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wes-app-meta-cache
+spec:
+  selector:
+    app: wes-app-meta-cache
+  ports:
+  - port: 6379
+    targetPort: redis

--- a/kubernetes/wes-app-meta-cache/statefulset.yaml
+++ b/kubernetes/wes-app-meta-cache/statefulset.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: wes-app-meta-cache
+spec:
+  selector:
+    matchLabels:
+      app: wes-app-meta-cache
+  serviceName: wes-app-meta-cache
+  template:
+    metadata:
+      labels:
+        app: wes-app-meta-cache
+    spec:
+      priorityClassName: wes-high-priority
+      nodeSelector:
+        node-role.kubernetes.io/master: "true"
+      containers:
+      - name: wes-app-meta-cache
+        image: redis:7.0.4
+        ports:
+        - containerPort: 6379
+          name: redis
+        volumeMounts:
+          - name: config
+            subPath: redis-config.conf
+            mountPath: /etc/redis-config.conf
+          - name: data
+            mountPath: /data
+      volumes:
+        - name: config
+          configMap:
+            name: wes-app-meta-cache-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: data
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 20Mi


### PR DESCRIPTION
This PR adds a small Redis service configured as an LRU cache which will be used to cache app pod metadata.

This metadata will be provided when apps are run and will be used by the wes-data-sharing-service to tag messages with system metadata from a trusted source.