### PR TITLE
Attemping to solve the bug of influxdb auth config not being set

### DIFF
--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -85,18 +85,6 @@ update_data_config() {
     fi
 }
 
-# TODO(sean) replace this with the influxdb builtin setup process. you can supply one time setup config + an admin token as env vars
-setup_influxdb() {
-    # retention time set to 1 week
-    kubectl exec svc/wes-node-influxdb -- influx setup \
-        --org waggle \
-        --bucket waggle \
-        --retention 7d \
-        --username waggle \
-        --password wagglewaggle \
-        --force
-}
-
 # NOTE the following section is really just a big reshaping of various configs and secrets
 # into bits that will be managed by kustomize. they're arguably simpler than before and we
 # could consider eventually just shipping the files as a tar / zip in rather than this:
@@ -355,7 +343,6 @@ EOF
     echo "setting influxdb..."
     # it is assumed that the commands below may fail.
     set +e
-    setup_influxdb
     TOKEN_NAME="waggle-read-write-bucket"
     # NOTE(sean) there have been nodes with multiple tokens named 'waggle-read-write-bucket', so we simply accept the first match.
     WAGGLE_INFLUXDB_TOKEN=$(kubectl exec svc/wes-node-influxdb -- influx auth ls | awk -v name="${TOKEN_NAME}" '$2 ~ name {print $3; exit}')

--- a/kubernetes/wes-node-influxdb.yaml
+++ b/kubernetes/wes-node-influxdb.yaml
@@ -34,6 +34,21 @@ spec:
         containers:
           - image: influxdb:2.1.1
             name: wes-node-influxdb
+            env:
+            - name: DOCKER_INFLUXDB_INIT_MODE
+              value: "setup"
+            - name: DOCKER_INFLUXDB_INIT_USERNAME
+              value: "waggle"
+            - name: DOCKER_INFLUXDB_INIT_PASSWORD
+              value: "wagglewaggle"
+            - name: DOCKER_INFLUXDB_INIT_ORG
+              value: "waggle"
+            - name: DOCKER_INFLUXDB_INIT_BUCKET
+              value: "waggle"
+            - name: DOCKER_INFLUXDB_INIT_RETENTION
+              value: "7d"
+            - name: INFLUX_CONFIGS_PATH
+              value: /var/lib/influxdb2/influx-configs
             resources:
               limits:
                 cpu: 500m
@@ -47,17 +62,7 @@ spec:
             volumeMounts:
               - mountPath: /var/lib/influxdb2
                 name: data
-              - mountPath: /etc/influxdb2
-                name: config
     volumeClaimTemplates:
-      - metadata:
-          name: config
-        spec:
-          accessModes:
-          - ReadWriteOnce
-          resources:
-            requests:
-              storage: 10M
       - metadata:
           name: data
         spec:


### PR DESCRIPTION
`wes-node-influxdb` creates `data` and `config` persistent volumes. We do not know the exact cause, but are experiencing that the influxdb does not store a user token in the `config` volume. This blocks any WES services using the token from accessing `wes-node-influxdb`.

The solution is to have `wes-node-influxdb` container initializing the setup and stores user token inside the `data` volume.

REQUIRED ACTIONS to apply this to existing Waggle nodes. This WILL lose all data in `wes-node-influxdb`
```
cd /PATH/TO/WES/REPO
kubectl delete -f wes-node-influxdb.yaml
kubectl delete pvc data-wes-node-influxdb-0
kubectl delete pvc config-wes-node-influxdb-0
```