### PR TITLE
Adding metrics scraper and new feature for pluginctl

### DIFF
--- a/kubernetes/cadvisor-exporter.yaml
+++ b/kubernetes/cadvisor-exporter.yaml
@@ -38,8 +38,8 @@ data:
   telegraf.conf: |            
     [[inputs.prometheus]]
       urls = ["https://kubernetes.default.svc.cluster.local:443/api/v1/nodes/${NODE_NAME}/proxy/metrics/cadvisor"]
-      bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
-      tls_ca = "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+      tls_ca = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 
     [[outputs.influxdb_v2]]
       urls = ["http://wes-node-influxdb.default.svc.cluster.local:8086"]

--- a/kubernetes/cadvisor-exporter.yaml
+++ b/kubernetes/cadvisor-exporter.yaml
@@ -1,0 +1,101 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: wes-telegraf-cadvisor
+  namespace: default
+rules:
+  - apiGroups: [""] # "" indicates the core API group
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: wes-telegraf-cadvisor-view
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: wes-telegraf-cadvisor
+  apiGroup: rbac.authorization.k8s.io
+  # `edit` is a built-in cluster role. more info about these can be found here:
+  # https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
+subjects:
+- kind: ServiceAccount
+  name: wes-telegraf-cadvisor-account
+  namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: wes-telegraf-cadvisor-account
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wes-telegraf-cadvisor-telegraf-config
+data:
+  telegraf.conf: |            
+    [[inputs.prometheus]]
+      urls = ["https://kubernetes.default.svc.cluster.local:443/api/v1/nodes/${NODE_NAME}/proxy/metrics/cadvisor"]
+      bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
+      tls_ca = "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+    [[outputs.influxdb_v2]]
+      urls = ["http://wes-node-influxdb.default.svc.cluster.local:8086"]
+      token = "${INFLUXDB_TOKEN}"
+      organization = "${INFLUXDB_ORG}"
+      bucket = "${INFLUXDB_BUCKET}"
+---
+# Runs one instance of node-exporter on every node (DaemonSet) and expose
+# the service on port 9100 on every node host.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: wes-telegraf-cadvisor
+  labels:
+    app.kubernetes.io/name: wes-telegraf-cadvisor
+    app.kubernetes.io/version: 1.22.4
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: wes-telegraf-cadvisor
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: wes-telegraf-cadvisor
+        app.kubernetes.io/version: 1.22.4
+    spec:
+      serviceAccountName: wes-telegraf-cadvisor-account
+      priorityClassName: wes-high-priority
+      containers:
+      - image: telegraf:1.22.4
+        name: wes-telegraf-cadvisor
+        resources:
+          limits:
+            cpu: 100m
+            memory: 60Mi
+          requests:
+            cpu: 50m
+            memory: 60Mi
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: INFLUXDB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: wes-node-influxdb-waggle-token
+                key: token
+          - name: INFLUXDB_BUCKET
+            value: "waggle"
+          - name: INFLUXDB_ORG
+            value: "waggle"
+        volumeMounts:
+          - mountPath: /etc/telegraf
+            name: telegraf-conf
+      volumes:
+      - name: telegraf-conf
+        configMap:
+          name: wes-telegraf-cadvisor-telegraf-config

--- a/kubernetes/jetson-exporter.yaml
+++ b/kubernetes/jetson-exporter.yaml
@@ -1,12 +1,11 @@
 # Runs one instance of jetson-exporter on every node (DaemonSet) and expose
-# the service on port 9100 on every node host.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: jetson-exporter
   labels:
     app.kubernetes.io/name: jetson-exporter
-    app.kubernetes.io/version: 0.0.0
+    app.kubernetes.io/version: 0.0.1
 spec:
   selector:
     matchLabels:
@@ -15,14 +14,15 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: jetson-exporter
-        app.kubernetes.io/version: 0.0.0
+        app.kubernetes.io/version: 0.0.1
     spec:
       nodeSelector:
         kubernetes.io/arch: "arm64"
         resource.gpu: "true"
       priorityClassName: wes-high-priority
       containers:
-      - image: waggle/jetson-exporter:0.0.0
+      - image: waggle/jetson-exporter:0.0.1
+        imagePullPolicy: Always
         name: jetson-exporter
         command: ["/app/jetson-exporter"]
         args:
@@ -31,6 +31,21 @@ spec:
         env:
         - name: PORT
           value: "9101"
+        - name: KUBENODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: INFLUXDB_URL
+          value: http://wes-node-influxdb.default.svc.cluster.local:8086
+        - name: INFLUXDB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: wes-node-influxdb-waggle-token
+              key: token
+        - name: INFLUXDB_ORG
+          value: waggle
+        - name: INFLUXDB_BUCKET
+          value: waggle
         resources:
           limits:
             cpu: 50m

--- a/kubernetes/jetson-exporter.yaml
+++ b/kubernetes/jetson-exporter.yaml
@@ -22,7 +22,6 @@ spec:
       priorityClassName: wes-high-priority
       containers:
       - image: waggle/jetson-exporter:0.0.1
-        imagePullPolicy: Always
         name: jetson-exporter
         command: ["/app/jetson-exporter"]
         args:

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -3,7 +3,7 @@ set -e
 
 WAGGLE_CONFIG_DIR="${WAGGLE_CONFIG_DIR:-/etc/waggle}"
 WAGGLE_BIN_DIR="${WAGGLE_BIN_DIR:-/usr/bin}"
-SES_VERSION="${SES_VERSION:-0.16.2}"
+SES_VERSION="${SES_VERSION:-0.16.8}"
 SES_TOOLS="${SES_TOOLS:-runplugin pluginctl sesctl}"
 
 fatal() {

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -412,6 +412,8 @@ resources:
   - wes-priority-classes.yaml
   - wes-plugin-network-policy.yaml
   # main components
+  - cadvisor-exporter.yaml
+  - jetson-exporter.yaml
   - node-exporter.yaml
   - wes-device-labeler.yaml
   - wes-audio-server.yaml

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -3,7 +3,7 @@ set -e
 
 WAGGLE_CONFIG_DIR="${WAGGLE_CONFIG_DIR:-/etc/waggle}"
 WAGGLE_BIN_DIR="${WAGGLE_BIN_DIR:-/usr/bin}"
-SES_VERSION="${SES_VERSION:-0.16.8}"
+SES_VERSION="${SES_VERSION:-0.17.0}"
 SES_TOOLS="${SES_TOOLS:-runplugin pluginctl sesctl}"
 
 fatal() {

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -347,24 +347,24 @@ EOF
     # NOTE(sean) there have been nodes with multiple tokens named 'waggle-read-write-bucket', so we simply accept the first match.
     WAGGLE_INFLUXDB_TOKEN=$(kubectl exec svc/wes-node-influxdb -- influx auth ls | awk -v name="${TOKEN_NAME}" '$2 ~ name {print $3; exit}')
     if [ -z "${WAGGLE_INFLUXDB_TOKEN}" ]; then
-        echo "creating influxdb token..."
+        echo "creating influxdb read-write token..."
         WAGGLE_INFLUXDB_TOKEN=$(kubectl exec svc/wes-node-influxdb -- influx auth create -u waggle -o waggle --hide-headers --read-buckets --write-buckets -d $TOKEN_NAME | awk '{print $3}')
     else
-        echo "token found. skipping creating influxdb token"
+        echo "token found. skipping creating influxdb read-write token"
     fi
     # NOTE(YK) This token is used for "pluginctl profile" to access wes-node-influxDB from host
     TOKEN_NAME="waggle-read-bucket"
     PLUGINCTL_INFLUXDB_TOKEN=$(kubectl exec svc/wes-node-influxdb -- influx auth ls | awk -v name="${TOKEN_NAME}" '$2 ~ name {print $3; exit}')
     if [ -z "${PLUGINCTL_INFLUXDB_TOKEN}" ]; then
-        echo "creating influxdb token..."
+        echo "creating influxdb read-only token..."
         PLUGINCTL_INFLUXDB_TOKEN=$(kubectl exec svc/wes-node-influxdb -- influx auth create -u waggle -o waggle --hide-headers --read-buckets -d $TOKEN_NAME | awk '{print $3}')
     else
-        echo "token found. skipping creating influxdb token"
+        echo "token found. skipping creating influxdb read-only token"
     fi
     mkdir -p /root/.influxdb2
-    cat ${PLUGINCTL_INFLUXDB_TOKEN} > /root/.influxdb2/token
+    echo ${PLUGINCTL_INFLUXDB_TOKEN} > /root/.influxdb2/token
     mkdir -p /home/waggle/.influxdb2
-    cat ${PLUGINCTL_INFLUXDB_TOKEN} > /home/waggle/.influxdb2/token
+    echo ${PLUGINCTL_INFLUXDB_TOKEN} > /home/waggle/.influxdb2/token
     set -e
 
     # HACK(sean) we add a "plain" wes-identity for plugins. kustomize will add a hash to wes-identity


### PR DESCRIPTION
- We added jetson-exporter for Jetson GPU metrics
- We added cadvisor-exporter using Telegraf to scrape cadvisor metrics
- We upped SES tool version to deploy the tools with new features (e.g., pluginctl with application performance profiling)