### PR TITLE
[SAGE-1554]Removed resource limits to make WES services process faste…

### DIFF
--- a/kubernetes/cadvisor-exporter.yaml
+++ b/kubernetes/cadvisor-exporter.yaml
@@ -72,11 +72,10 @@ spec:
       - image: telegraf:1.22.4
         name: wes-telegraf-cadvisor
         resources:
-          limits:
+          requests:
             cpu: 100m
             memory: 60Mi
-          requests:
-            cpu: 50m
+          limits:
             memory: 60Mi
         env:
           - name: NODE_NAME

--- a/kubernetes/jetson-exporter.yaml
+++ b/kubernetes/jetson-exporter.yaml
@@ -46,11 +46,10 @@ spec:
         - name: INFLUXDB_BUCKET
           value: waggle
         resources:
-          limits:
-            cpu: 50m
-            memory: 50Mi
           requests:
-            cpu: 50m
+            cpu: 100m
+            memory: 50Mi
+          limits:
             memory: 50Mi
         ports:
         - name: http

--- a/kubernetes/node-exporter.yaml
+++ b/kubernetes/node-exporter.yaml
@@ -31,10 +31,9 @@ spec:
         name: node-exporter
         resources:
           limits:
-            cpu: 50m
             memory: 60Mi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 60Mi
         ports:
         - name: http

--- a/kubernetes/wes-app-meta-cache/statefulset.yaml
+++ b/kubernetes/wes-app-meta-cache/statefulset.yaml
@@ -19,11 +19,10 @@ spec:
       - name: wes-app-meta-cache
         image: redis:7.0.4
         resources:
-          limits:
-            cpu: 50m
-            memory: 20Mi
           requests:
-            cpu: 50m
+            cpu: 100m
+            memory: 20Mi
+          limits:
             memory: 20Mi
         ports:
         - containerPort: 6379

--- a/kubernetes/wes-audio-server.yaml
+++ b/kubernetes/wes-audio-server.yaml
@@ -32,7 +32,6 @@ spec:
           name: wes-audio-server
           resources:
             limits:
-              cpu: 200m
               memory: 20Mi
             requests:
               cpu: 200m

--- a/kubernetes/wes-camera-provisioner.yaml
+++ b/kubernetes/wes-camera-provisioner.yaml
@@ -63,12 +63,11 @@ spec:
           - name: wes-camera-provisioner
             image: waggle/wes-camera-provisioner:0.0.9
             resources:
-              limits:
+              requests:
                 cpu: 200m
                 memory: 100Mi
-              requests:
-                cpu: 100m
-                memory: 50Mi
+              limits:
+                memory: 100Mi
             env:
             - name: WAGGLE_CAMERA_ADMIN
               valueFrom:

--- a/kubernetes/wes-data-sharing-service.yaml
+++ b/kubernetes/wes-data-sharing-service.yaml
@@ -18,9 +18,6 @@ spec:
         - name: wes-data-sharing-service
           image: waggle/wes-data-sharing-service:0.12.2
           resources:
-            limits:
-              cpu: 100m
-              memory: 40Mi
             requests:
               cpu: 100m
               memory: 40Mi

--- a/kubernetes/wes-data-sharing-service.yaml
+++ b/kubernetes/wes-data-sharing-service.yaml
@@ -19,8 +19,10 @@ spec:
           image: waggle/wes-data-sharing-service:0.12.2
           resources:
             requests:
-              cpu: 100m
-              memory: 40Mi
+              cpu: 200m
+              memory: 50Mi
+            limits:
+              memory: 50Mi
           envFrom:
             - configMapRef:
                 name: wes-identity

--- a/kubernetes/wes-default-limits.yaml
+++ b/kubernetes/wes-default-limits.yaml
@@ -5,9 +5,8 @@ metadata:
 spec:
   limits:
     - default:
-        cpu: 1000m
         memory: 1Gi
       defaultRequest:
         cpu: 500m
-        memory: 512Mi
+        memory: 1Gi
       type: Container

--- a/kubernetes/wes-device-labeler.yaml
+++ b/kubernetes/wes-device-labeler.yaml
@@ -20,10 +20,9 @@ spec:
           image: waggle/wes-device-labeler:0.4.0
           resources:
             limits:
-              cpu: 50m
+              cpu: 100m
               memory: 75Mi
             requests:
-              cpu: 50m
               memory: 75Mi
           args:
             # - "--dry-run"

--- a/kubernetes/wes-gps-server.yaml
+++ b/kubernetes/wes-gps-server.yaml
@@ -36,7 +36,6 @@ spec:
             privileged: true
           resources:
             limits:
-              cpu: 50m
               memory: 10Mi
             requests:
               cpu: 50m

--- a/kubernetes/wes-metrics-agent.yaml
+++ b/kubernetes/wes-metrics-agent.yaml
@@ -21,7 +21,6 @@ spec:
             privileged: true
           resources:
             limits:
-              cpu: 100m
               memory: 60Mi
             requests:
               cpu: 100m

--- a/kubernetes/wes-node-influxdb-loader.yaml
+++ b/kubernetes/wes-node-influxdb-loader.yaml
@@ -19,7 +19,9 @@ spec:
         name: wes-node-influxdb-loader
         resources:
           requests:
-            cpu: 50m
+            cpu: 200m
+            memory: 100Mi
+          limits:
             memory: 100Mi
         ports:
         - name: metrics

--- a/kubernetes/wes-node-influxdb-loader.yaml
+++ b/kubernetes/wes-node-influxdb-loader.yaml
@@ -15,12 +15,9 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: "true"
       containers:
-      - image: waggle/node-influxdb-loader:0.0.0
+      - image: waggle/node-influxdb-loader:0.0.1
         name: wes-node-influxdb-loader
         resources:
-          limits:
-            cpu: 100m
-            memory: 150Mi
           requests:
             cpu: 50m
             memory: 100Mi

--- a/kubernetes/wes-node-influxdb.yaml
+++ b/kubernetes/wes-node-influxdb.yaml
@@ -51,7 +51,7 @@ spec:
               value: /var/lib/influxdb2/influx-configs
             resources:
               limits:
-                cpu: 500m
+                cpu: 1000m
                 memory: 500Mi
               requests:
                 cpu: 300m

--- a/kubernetes/wes-node-influxdb.yaml
+++ b/kubernetes/wes-node-influxdb.yaml
@@ -51,11 +51,10 @@ spec:
               value: /var/lib/influxdb2/influx-configs
             resources:
               limits:
-                cpu: 1000m
                 memory: 500Mi
               requests:
-                cpu: 300m
-                memory: 100Mi
+                cpu: 500m
+                memory: 500Mi
             ports:
               - containerPort: 8086
                 name: influxdb

--- a/kubernetes/wes-plugin-scheduler.yaml
+++ b/kubernetes/wes-plugin-scheduler.yaml
@@ -51,11 +51,10 @@ spec:
               fieldPath: metadata.uid
         resources:
           limits:
-            cpu: 200m
             memory: 150Mi
           requests:
             cpu: 100m
-            memory: 100Mi
+            memory: 150Mi
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/kubernetes/wes-rabbitmq.yaml
+++ b/kubernetes/wes-rabbitmq.yaml
@@ -38,7 +38,6 @@ spec:
           image: rabbitmq:3.8.11-management-alpine
           resources:
             limits:
-              cpu: 1000m
               memory: 1Gi
             requests:
               cpu: 500m

--- a/kubernetes/wes-rabbitmq.yaml
+++ b/kubernetes/wes-rabbitmq.yaml
@@ -38,7 +38,7 @@ spec:
           image: rabbitmq:3.8.11-management-alpine
           resources:
             limits:
-              cpu: 500m
+              cpu: 1000m
               memory: 1Gi
             requests:
               cpu: 500m

--- a/kubernetes/wes-sciencerule-checker.yaml
+++ b/kubernetes/wes-sciencerule-checker.yaml
@@ -1,15 +1,20 @@
 apiVersion: v1
 kind: Service
 metadata:
-    name: wes-sciencerule-checker
+  name: wes-sciencerule-checker
 spec:
-    ports:
-      - name: wes-sciencerule-checker
-        port: 5000
-        targetPort: 5000
-    selector:
-        app: wes-sciencerule-checker
-    type: ClusterIP
+  ports:
+  - name: api
+    port: 5000
+    targetPort: api
+    protocol: TCP
+  - name: metrics
+    port: 8000
+    targetPort: metrics
+    protocol: TCP
+  selector:
+    app: wes-sciencerule-checker
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -28,7 +33,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: "true"
       containers:
-      - image: waggle/sciencerule-checker:0.0.6
+      - image: waggle/sciencerule-checker:0.0.7
         name: wes-sciencerule-checker
         env:
         - name: NODE_INFLUXDB_URL
@@ -41,6 +46,8 @@ spec:
         ports:
         - name: api
           containerPort: 5000
+        - name: metrics
+          containerPort: 8000
         resources:
           limits:
             memory: 150Mi

--- a/kubernetes/wes-sciencerule-checker.yaml
+++ b/kubernetes/wes-sciencerule-checker.yaml
@@ -28,7 +28,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: "true"
       containers:
-      - image: waggle/sciencerule-checker:0.0.2
+      - image: waggle/sciencerule-checker:0.0.6
         name: wes-sciencerule-checker
         env:
         - name: NODE_INFLUXDB_URL

--- a/kubernetes/wes-sciencerule-checker.yaml
+++ b/kubernetes/wes-sciencerule-checker.yaml
@@ -43,8 +43,7 @@ spec:
           containerPort: 5000
         resources:
           limits:
-            cpu: 150m
             memory: 150Mi
           requests:
             cpu: 100m
-            memory: 100Mi
+            memory: 150Mi

--- a/kubernetes/wes-scoreboard.yaml
+++ b/kubernetes/wes-scoreboard.yaml
@@ -32,8 +32,7 @@ spec:
         name: wes-scoreboard
         resources:
           limits:
-            cpu: 100m
             memory: 150Mi
           requests:
             cpu: 50m
-            memory: 100Mi
+            memory: 150Mi

--- a/kubernetes/wes-upload-agent.yaml
+++ b/kubernetes/wes-upload-agent.yaml
@@ -23,7 +23,6 @@ spec:
           name: wes-upload-agent
           resources:
             limits:
-              cpu: 250m
               memory: 25Mi
             requests:
               cpu: 250m


### PR DESCRIPTION
…r on larger volume of message

This changes,
- both wes-data-sharing-service and wes-node-influxdb-loader no longer have resource limits. They can process messages as fast they want (this may cause other pods being starved)
- Upped CPU limits on wes-rabbitmq and wes-influxdb. We can also relief the limits, but I think they should not require more than 1 CPU if messages are well handled by the loaders.
- wes-node-influxdb-loader tolerates length of values in meta information. It was a problem if a meta value exceeds 64 characters (now up to 256 characters).