### PR TITLE
SAGE-1586: relax liveness probe for chirpstack services

### DIFF
--- a/kubernetes/wes-chirpstack/wes-chirpstack-gateway-deployment.yaml
+++ b/kubernetes/wes-chirpstack/wes-chirpstack-gateway-deployment.yaml
@@ -69,13 +69,15 @@ spec:
             httpGet:
               port: metrics
             initialDelaySeconds: 5
-            failureThreshold: 30
-            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 5
+            periodSeconds: 60
           livenessProbe:
             httpGet:
               port: metrics
+            timeoutSeconds: 10
             failureThreshold: 3
-            periodSeconds: 10
+            periodSeconds: 60
       volumes:
         - name: gateway-bridge-config-volume
           configMap:

--- a/kubernetes/wes-chirpstack/wes-chirpstack-postgresql-deployment.yaml
+++ b/kubernetes/wes-chirpstack/wes-chirpstack-postgresql-deployment.yaml
@@ -42,13 +42,15 @@ spec:
             tcpSocket:
               port: postgresql
             initialDelaySeconds: 5
-            failureThreshold: 30
-            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 5
+            periodSeconds: 60
           livenessProbe:
             tcpSocket:
               port: postgresql
+            timeoutSeconds: 10
             failureThreshold: 3
-            periodSeconds: 10
+            periodSeconds: 60
       volumes:
         - name: chirpstack-postgresql-data-volume
           persistentVolumeClaim:

--- a/kubernetes/wes-chirpstack/wes-chirpstack-redis-deployment.yaml
+++ b/kubernetes/wes-chirpstack/wes-chirpstack-redis-deployment.yaml
@@ -36,8 +36,9 @@ spec:
           livenessProbe:
             tcpSocket:
               port: redis
+            timeoutSeconds: 10
             failureThreshold: 3
-            periodSeconds: 10
+            periodSeconds: 60
       volumes:
         - name: chirpstack-redis-data-volume
           persistentVolumeClaim:

--- a/kubernetes/wes-chirpstack/wes-chirpstack-server-deployment.yaml
+++ b/kubernetes/wes-chirpstack/wes-chirpstack-server-deployment.yaml
@@ -75,14 +75,16 @@ spec:
               path: /health
               port: metrics
             initialDelaySeconds: 5
-            failureThreshold: 30
-            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 5
+            periodSeconds: 60
           livenessProbe:
             httpGet:
               path: /health
               port: metrics
+            timeoutSeconds: 10
             failureThreshold: 3
-            periodSeconds: 10
+            periodSeconds: 60
       volumes:
         - name: server-config-volume
           configMap:


### PR DESCRIPTION
The default 1s liveness probe was too short for a busy node, resulting in unnecessary pod restarts.

Additionally, only perform the probe checks every 60 seconds.