### PR TITLE
[SAGE-1569] Reset influxDB when 401 occurs

### DIFF
--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -417,8 +417,9 @@ EOF
     set +e
     TOKEN_NAME="waggle-read-write-bucket"
     INFLUXDB_UNAUTHORIZED=$(kubectl exec svc/wes-node-influxdb -- influx auth ls 2>&1 | grep "Unauthorized")
-    if [ -z "${INFLUXDB_UNAUTHORIZED}" ]; then
-        echo "failed to check influxDB auth"
+    if [ ! -z "${INFLUXDB_UNAUTHORIZED}" ]; then
+        echo "failed to check influxDB auth. Access token is missing"
+        echo "influxDB and its PVCs will be deleted to reset them"
         delete_influxdb_pvc
     fi
     # NOTE(sean) there have been nodes with multiple tokens named 'waggle-read-write-bucket', so we simply accept the first match.


### PR DESCRIPTION
wes-node-influxDB has admin token to create user tokens for other services to get access to the database. The Waggle nodes with the WES not being updated suffer from missing the admin token (due to the old mechanism they have in WES). This checks if influxDB misses the admin token and resets it to fix this problem. 