### PR TITLE
SAGE-1605: Added liveness probe to RabbitMQ

### DIFF
--- a/kubernetes/wes-rabbitmq.yaml
+++ b/kubernetes/wes-rabbitmq.yaml
@@ -52,6 +52,15 @@ spec:
               readOnly: true
             - name: data
               mountPath: /var/lib/rabbitmq
+          livenessProbe:
+            exec:
+              command:
+                - bash
+                - -c
+                - rabbitmq-diagnostics -q ping && rabbitmq-diagnostics -q list_queues --no-table-headers | awk '/to-validator/ && $2 > 10000 {print "to-validator queue backed up"; exit 1}'
+            timeoutSeconds: 10
+            periodSeconds: 60
+            failureThreshold: 60
       volumes:
         - name: config
           secret:

--- a/kubernetes/wes-rabbitmq.yaml
+++ b/kubernetes/wes-rabbitmq.yaml
@@ -58,7 +58,7 @@ spec:
                 - bash
                 - -c
                 - rabbitmq-diagnostics -q ping && rabbitmq-diagnostics -q list_queues --no-table-headers | awk '/to-validator/ && $2 > 10000 {print "to-validator queue backed up"; exit 1}'
-            timeoutSeconds: 10
+            timeoutSeconds: 30
             periodSeconds: 60
             failureThreshold: 60
       volumes:


### PR DESCRIPTION
This PR adds a liveness probe to RabbitMQ which:
1. Pings RabbitMQ to see if it responds at all.
2. Checks if the to-validator queue is backing up (> 10K messages).

It is set to run every minute and must fail 60 times (~an hour) before kicking in.

Feedback on this specific choice would be good but I didn't want the probe to be overly aggressive. For example, if RabbitMQ recovers and starts processing the to-validator queue, I didn't want it to keep restarting while above the 10K threshold.
