### PR TITLE
SAGE-1619 [wes-camera-provisioner] make compatible with new node K3S version

### DIFF
--- a/kubernetes/wes-camera-provisioner.yaml
+++ b/kubernetes/wes-camera-provisioner.yaml
@@ -41,7 +41,7 @@ data:
             Hostname ssh.github.com
             IdentityFile /keys/hanwha_client_key
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: wes-camera-provisioner


### PR DESCRIPTION
The new K3S version (v1.25.4) has moved this CronJob out of beta, so the 'beta' version is no longer required.