### PR TITLE
Verify checksums for SES tools.

### DIFF
--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -53,17 +53,16 @@ update_wes_tools() {
     # extract checksums for current arch
     grep "${arch}" /tmp/sestools-sha256sum.txt > "/tmp/sestools-sha256sum-${arch}.txt"
 
-    # collect files which fail checksum
+    # collect files which fail checksum (or do not exist) and download
     files_to_download=$(cd "${WAGGLE_BIN_DIR}" && shasum -a 256 -c "/tmp/sestools-sha256sum-${arch}.txt" | awk -F: '/FAILED/ {print $1}')
 
-    # download files which failed
     for name in $files_to_download; do
         echo "downloading ${name}..."
         url="https://github.com/waggle-sensor/edge-scheduler/releases/download/${SES_VERSION}/${name}"
         wget -q --timeout 300 "${url}" -O "${WAGGLE_BIN_DIR}/${name}"
     done
 
-    # ensure permissions and links are up to date
+    # ensure permissions and links are correct
     for name in $SES_TOOLS; do
         chmod +x "${WAGGLE_BIN_DIR}/${name}-${arch}"
         ln -f "${WAGGLE_BIN_DIR}/${name}-${arch}" "${WAGGLE_BIN_DIR}/${name}"

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -3,7 +3,7 @@ set -e
 
 WAGGLE_CONFIG_DIR="${WAGGLE_CONFIG_DIR:-/etc/waggle}"
 WAGGLE_BIN_DIR="${WAGGLE_BIN_DIR:-/usr/bin}"
-SES_VERSION="${SES_VERSION:-0.20.0}"
+SES_VERSION="${SES_VERSION:-0.20.2}"
 SES_TOOLS="${SES_TOOLS:-runplugin pluginctl sesctl}"
 NODE_MANIFEST_V2="${NODE_MANIFEST_V2:-node-manifest-v2.json}"
 


### PR DESCRIPTION
This PR uses the newly added sha256sum.txt file created as part of edge scheduler releases to verify SES tools' checksums and update those which do not match.

This will help provide a more correct check for interrupted downloads or corrupted tools.
