### PR TITLE
Add image pull policy IfNotPresent to all resources

### DIFF
--- a/kubernetes/cadvisor-exporter.yaml
+++ b/kubernetes/cadvisor-exporter.yaml
@@ -79,8 +79,9 @@ spec:
       serviceAccountName: wes-telegraf-cadvisor-account
       priorityClassName: wes-high-priority
       containers:
-        - image: telegraf:1.22.4
-          name: wes-telegraf-cadvisor
+        - name: wes-telegraf-cadvisor
+          image: telegraf:1.22.4
+          imagePullPolicy: IfNotPresent
           resources:
             requests:
               cpu: 100m

--- a/kubernetes/dcgm-exporter.yaml
+++ b/kubernetes/dcgm-exporter.yaml
@@ -30,6 +30,7 @@ spec:
               add:
                 - SYS_ADMIN
           image: nvcr.io/nvidia/k8s/dcgm-exporter:3.0.4-3.0.0-ubuntu20.04
+          imagePullPolicy: IfNotPresent
           name: dcgm-exporter
           env:
             - name: DCGM_EXPORTER_KUBERNETES

--- a/kubernetes/debug/find-invalid-image-pull-policy.py
+++ b/kubernetes/debug/find-invalid-image-pull-policy.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 from pathlib import Path
 import yaml
 
@@ -10,7 +11,7 @@ def find_containers(x):
                 walk(item, containers)
         elif isinstance(obj, dict):
             for key, item in obj.items():
-                if key == "containers":
+                if key in ["containers", "initContainers"]:
                     containers += item
                 walk(item, containers)
 
@@ -20,9 +21,13 @@ def find_containers(x):
 
 
 def main():
-    kube_dir = Path(__file__).parent.parent
+    wes_kube_dir = Path(__file__).parent.parent
 
-    for file in kube_dir.glob("**/*.yaml"):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=wes_kube_dir, type=Path)
+    args = parser.parse_args()
+
+    for file in args.root.glob("**/*.yaml"):
         for doc in yaml.safe_load_all(file.read_text()):
             for container in find_containers(doc):
                 if container.get("imagePullPolicy") != "IfNotPresent":

--- a/kubernetes/debug/find-invalid-image-pull-policy.py
+++ b/kubernetes/debug/find-invalid-image-pull-policy.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import yaml
+
+
+def find_containers(x):
+    def walk(obj, containers):
+        if isinstance(obj, list):
+            for item in obj:
+                walk(item, containers)
+        elif isinstance(obj, dict):
+            for key, item in obj.items():
+                if key == "containers":
+                    containers += item
+                walk(item, containers)
+
+    containers = []
+    walk(x, containers)
+    return containers
+
+
+def main():
+    kube_dir = Path(__file__).parent.parent
+
+    for file in kube_dir.glob("**/*.yaml"):
+        for doc in yaml.safe_load_all(file.read_text()):
+            for container in find_containers(doc):
+                if container.get("imagePullPolicy") != "IfNotPresent":
+                    print(file, container["name"])
+
+
+if __name__ == "__main__":
+    main()

--- a/kubernetes/jetson-exporter.yaml
+++ b/kubernetes/jetson-exporter.yaml
@@ -21,8 +21,9 @@ spec:
         resource.gpu: "true"
       priorityClassName: wes-high-priority
       containers:
-        - image: waggle/jetson-exporter:0.0.1
-          name: jetson-exporter
+        - name: jetson-exporter
+          image: waggle/jetson-exporter:0.0.1
+          imagePullPolicy: IfNotPresent
           command: ["/app/jetson-exporter"]
           args:
             - --loadpath

--- a/kubernetes/node-exporter.yaml
+++ b/kubernetes/node-exporter.yaml
@@ -19,7 +19,10 @@ spec:
     spec:
       priorityClassName: wes-high-priority
       containers:
-        - args:
+        - name: node-exporter
+          image: prom/node-exporter:v1.0.1
+          imagePullPolicy: IfNotPresent
+          args:
             - "--web.listen-address=$(HOST_IP):9100"
             - "--path.procfs=/host/proc"
             - "--path.sysfs=/host/sys"
@@ -27,8 +30,6 @@ spec:
             - "--collector.netdev.device-blacklist=^veth"
             - "--collector.netclass.ignored-devices=^veth"
             - "--collector.filesystem.ignored-mount-points=^/(dev|proc|run|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)"
-          image: prom/node-exporter:v1.0.1
-          name: node-exporter
           resources:
             limits:
               memory: 60Mi

--- a/kubernetes/nvidia-device-plugin.yaml
+++ b/kubernetes/nvidia-device-plugin.yaml
@@ -41,8 +41,9 @@ spec:
       # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
       priorityClassName: "system-node-critical"
       containers:
-        - image: nvcr.io/nvidia/k8s-device-plugin:v0.12.3
-          name: nvidia-device-plugin-ctr
+        - name: nvidia-device-plugin-ctr
+          image: nvcr.io/nvidia/k8s-device-plugin:v0.12.3
+          imagePullPolicy: IfNotPresent
           env:
             - name: FAIL_ON_INIT_ERROR
               value: "false"

--- a/kubernetes/ros/wes-roscore.yaml
+++ b/kubernetes/ros/wes-roscore.yaml
@@ -29,6 +29,7 @@ spec:
       containers:
         - name: wes-roscore
           image: lblanp/panda:plugin-roscore
+          imagePullPolicy: IfNotPresent
           resources:
             requests:
               cpu: 200m

--- a/kubernetes/wes-app-meta-cache/statefulset.yaml
+++ b/kubernetes/wes-app-meta-cache/statefulset.yaml
@@ -18,6 +18,7 @@ spec:
       containers:
         - name: wes-app-meta-cache
           image: waggle/app-meta-cache:0.1.0
+          imagePullPolicy: IfNotPresent
           args: ["/etc/redis-config.conf"]
           resources:
             requests:

--- a/kubernetes/wes-audio-server.yaml
+++ b/kubernetes/wes-audio-server.yaml
@@ -28,8 +28,9 @@ spec:
       nodeSelector:
         resource.microphone: "true"
       containers:
-        - image: waggle/wes-audio-server:0.3.0
-          name: wes-audio-server
+        - name: wes-audio-server
+          image: waggle/wes-audio-server:0.3.0
+          imagePullPolicy: IfNotPresent
           resources:
             limits:
               memory: 20Mi

--- a/kubernetes/wes-camera-provisioner.yaml
+++ b/kubernetes/wes-camera-provisioner.yaml
@@ -62,6 +62,7 @@ spec:
           containers:
             - name: wes-camera-provisioner
               image: waggle/wes-camera-provisioner:0.1.3
+              imagePullPolicy: IfNotPresent
               resources:
                 requests:
                   cpu: 200m

--- a/kubernetes/wes-chirpstack/wes-chirpstack-gateway-deployment.yaml
+++ b/kubernetes/wes-chirpstack/wes-chirpstack-gateway-deployment.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
         - name: wes-lorawan-gateway
           image: rakwireless/udp-packet-forwarder:v1.1.3
+          imagePullPolicy: IfNotPresent
           # Need this to get access to write so /sys (gpio)
           securityContext:
             privileged: true
@@ -47,6 +48,7 @@ spec:
               readOnly: false
         - name: wes-chirpstack-gateway-bridge
           image: chirpstack/chirpstack-gateway-bridge:4.0.1
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 1700
               protocol: UDP

--- a/kubernetes/wes-chirpstack/wes-chirpstack-postgresql-statefulset.yaml
+++ b/kubernetes/wes-chirpstack/wes-chirpstack-postgresql-statefulset.yaml
@@ -19,6 +19,7 @@ spec:
       containers:
         - name: wes-chirpstack-postgresql
           image: postgres:15.0-alpine3.16
+          imagePullPolicy: IfNotPresent
           ports:
             - name: postgresql
               containerPort: 5432

--- a/kubernetes/wes-chirpstack/wes-chirpstack-redis-statefulset.yaml
+++ b/kubernetes/wes-chirpstack/wes-chirpstack-redis-statefulset.yaml
@@ -19,6 +19,7 @@ spec:
       containers:
         - name: wes-chirpstack-redis
           image: redis:7.0.4-alpine3.16
+          imagePullPolicy: IfNotPresent
           ports:
             - name: redis
               containerPort: 6379

--- a/kubernetes/wes-chirpstack/wes-chirpstack-server-deployment.yaml
+++ b/kubernetes/wes-chirpstack/wes-chirpstack-server-deployment.yaml
@@ -15,6 +15,7 @@ spec:
       containers:
         - name: wes-chirpstack-server
           image: waggle/wes-chirpstack-server:0.1.0
+          imagePullPolicy: IfNotPresent
           command: ["chirpstack"]
           args: ["-c", "/etc/chirpstack-waggle"]
           lifecycle:

--- a/kubernetes/wes-data-sharing-service.yaml
+++ b/kubernetes/wes-data-sharing-service.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
         - name: wes-data-sharing-service
           image: waggle/wes-data-sharing-service:0.14.0
+          imagePullPolicy: IfNotPresent
           resources:
             requests:
               cpu: 200m

--- a/kubernetes/wes-dev-notebook.yaml
+++ b/kubernetes/wes-dev-notebook.yaml
@@ -30,6 +30,7 @@ spec:
       containers:
         - name: wes-dev-notebook
           image: docker.io/waggle/plugin-base:1.1.1-ml
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8888
           command:
@@ -38,7 +39,6 @@ spec:
             - "--LabApp.token=waggle"
             - "--LabApp.ip=0.0.0.0"
             - "--LabApp.allow_root=True"
-          imagePullPolicy: IfNotPresent
           env:
             - name: PULSE_SERVER
               value: tcp:wes-audio-server:4713

--- a/kubernetes/wes-device-labeler.yaml
+++ b/kubernetes/wes-device-labeler.yaml
@@ -18,6 +18,7 @@ spec:
       containers:
         - name: wes-device-labeler
           image: waggle/wes-device-labeler:0.5.3
+          imagePullPolicy: IfNotPresent
           resources:
             limits:
               memory: 75Mi

--- a/kubernetes/wes-gps-server.yaml
+++ b/kubernetes/wes-gps-server.yaml
@@ -28,8 +28,9 @@ spec:
       nodeSelector:
         resource.gps: "true"
       containers:
-        - image: waggle/wes-gps-server:0.1.1
-          name: wes-gps-server
+        - name: wes-gps-server
+          image: waggle/wes-gps-server:0.1.1
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 2947
           securityContext:

--- a/kubernetes/wes-metrics-agent.yaml
+++ b/kubernetes/wes-metrics-agent.yaml
@@ -15,8 +15,9 @@ spec:
     spec:
       priorityClassName: wes-high-priority
       containers:
-        - image: waggle/wes-metrics-agent:0.8.2
-          name: wes-metrics-agent
+        - name: wes-metrics-agent
+          image: waggle/wes-metrics-agent:0.8.2
+          imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
           resources:

--- a/kubernetes/wes-node-influxdb-loader.yaml
+++ b/kubernetes/wes-node-influxdb-loader.yaml
@@ -15,8 +15,9 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: "true"
       containers:
-        - image: waggle/node-influxdb-loader:0.0.1
-          name: wes-node-influxdb-loader
+        - name: wes-node-influxdb-loader
+          image: waggle/node-influxdb-loader:0.0.1
+          imagePullPolicy: IfNotPresent
           resources:
             requests:
               cpu: 200m

--- a/kubernetes/wes-node-influxdb.yaml
+++ b/kubernetes/wes-node-influxdb.yaml
@@ -32,8 +32,9 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: "true"
       containers:
-        - image: influxdb:2.1.1
-          name: wes-node-influxdb
+        - name: wes-node-influxdb
+          image: influxdb:2.1.1
+          imagePullPolicy: IfNotPresent
           env:
             - name: DOCKER_INFLUXDB_INIT_MODE
               value: "setup"

--- a/kubernetes/wes-playback-server.yaml
+++ b/kubernetes/wes-playback-server.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       containers:
         - image: waggle/wes-playback-server:0.1.0
+          imagePullPolicy: IfNotPresent
           name: wes-playback-server
           ports:
             - containerPort: 8090

--- a/kubernetes/wes-plugin-scheduler.yaml
+++ b/kubernetes/wes-plugin-scheduler.yaml
@@ -31,6 +31,7 @@ spec:
         node-role.kubernetes.io/master: "true"
       containers:
         - image: waggle/edge-scheduler:0.22.4
+          imagePullPolicy: IfNotPresent
           name: wes-plugin-scheduler
           command: ["nodescheduler"]
           args:

--- a/kubernetes/wes-rabbitmq.yaml
+++ b/kubernetes/wes-rabbitmq.yaml
@@ -36,6 +36,7 @@ spec:
       containers:
         - name: wes-rabbitmq
           image: rabbitmq:3.8.11-management-alpine
+          imagePullPolicy: IfNotPresent
           resources:
             limits:
               memory: 1Gi

--- a/kubernetes/wes-sciencerule-checker.yaml
+++ b/kubernetes/wes-sciencerule-checker.yaml
@@ -34,6 +34,7 @@ spec:
         node-role.kubernetes.io/master: "true"
       containers:
         - image: waggle/sciencerule-checker:0.0.7
+          imagePullPolicy: IfNotPresent
           name: wes-sciencerule-checker
           env:
             - name: NODE_INFLUXDB_URL

--- a/kubernetes/wes-scoreboard.yaml
+++ b/kubernetes/wes-scoreboard.yaml
@@ -29,6 +29,7 @@ spec:
       priorityClassName: wes-high-priority
       containers:
         - image: redis:7.0.4
+          imagePullPolicy: IfNotPresent
           name: wes-scoreboard
           resources:
             limits:

--- a/kubernetes/wes-update-waggle-ssh-keys.yaml
+++ b/kubernetes/wes-update-waggle-ssh-keys.yaml
@@ -14,6 +14,7 @@ spec:
           containers:
           - name: wes-update-waggle-ssh-keys
             image: alpine:3.17.2
+            imagePullPolicy: IfNotPresent
             command: ["/bin/sh", "-c"]
             args: ['wget "https://auth.sagecontinuum.org/nodes/${WAGGLE_NODE_VSN}/authorized_keys" -O /home/waggle/.ssh/authorized_keys2.update && mv /home/waggle/.ssh/authorized_keys2.update /home/waggle/.ssh/authorized_keys2']
             envFrom:

--- a/kubernetes/wes-upload-agent.yaml
+++ b/kubernetes/wes-upload-agent.yaml
@@ -19,8 +19,9 @@ spec:
         - key: "node.kubernetes.io/disk-pressure"
           operator: "Exists"
       containers:
-        - image: waggle/wes-upload-agent:0.5.0
-          name: wes-upload-agent
+        - name: wes-upload-agent
+          image: waggle/wes-upload-agent:0.5.0
+          imagePullPolicy: IfNotPresent
           resources:
             limits:
               memory: 25Mi


### PR DESCRIPTION
This PR sets the image pull policy to IfNotPresent for all WES resources.

Since we should be tagging all container images WES uses, this will totally eliminate extra image checks and pulls.