### PR TITLE
Reviving jetson-exporter

### DIFF
--- a/kubernetes/jetson-exporter.yaml
+++ b/kubernetes/jetson-exporter.yaml
@@ -1,11 +1,28 @@
-# Runs one instance of jetson-exporter on every node (DaemonSet) and expose
+# externalTrafficPolicy and internalTrafficPolicy make the metrics
+# only available within the node
+apiVersion: v1
+kind: Service
+metadata:
+  name: wes-jetson-exporter-local
+spec:
+  selector:
+    app: jetson-exporter
+  ports:
+    - name: http
+      protocol: TCP
+      port: 9101
+      targetPort: http
+  type: ClusterIP
+  externalTrafficPolicy: Local
+  internalTrafficPolicy: Local
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: jetson-exporter
   labels:
     app.kubernetes.io/name: jetson-exporter
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.0.2
 spec:
   selector:
     matchLabels:
@@ -14,16 +31,16 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: jetson-exporter
-        app.kubernetes.io/version: 0.0.1
+        app.kubernetes.io/version: 0.0.2
+        app: jetson-exporter
     spec:
       nodeSelector:
         kubernetes.io/arch: "arm64"
         resource.gpu: "true"
       priorityClassName: wes-high-priority
       containers:
-        - name: jetson-exporter
-          image: waggle/jetson-exporter:0.0.1
-          imagePullPolicy: IfNotPresent
+        - image: waggle/jetson-exporter:0.0.2
+          name: jetson-exporter
           command: ["/app/jetson-exporter"]
           args:
             - --loadpath
@@ -35,17 +52,20 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: INFLUXDB_URL
-              value: http://wes-node-influxdb.default.svc.cluster.local:8086
-            - name: INFLUXDB_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: wes-node-influxdb-waggle-token
-                  key: token
-            - name: INFLUXDB_ORG
-              value: waggle
-            - name: INFLUXDB_BUCKET
-              value: waggle
+# (Todo) Yongho: this sometimes makes the pod use too much resources
+# and create warnings and errors when the influxDB is throttled.
+# This should be disabled until we can ensure this does not create the problems
+#            - name: INFLUXDB_URL
+#              value: http://wes-node-influxdb.default.svc.cluster.local:8086
+#            - name: INFLUXDB_TOKEN
+#              valueFrom:
+#                secretKeyRef:
+#                  name: wes-node-influxdb-waggle-token
+#                  key: token
+#            - name: INFLUXDB_ORG
+#              value: waggle
+#            - name: INFLUXDB_BUCKET
+#              value: waggle
           resources:
             requests:
               cpu: 100m

--- a/kubernetes/jetson-exporter.yaml
+++ b/kubernetes/jetson-exporter.yaml
@@ -3,36 +3,33 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: wes-jetson-exporter-local
+  name: wes-jetson-exporter
 spec:
   selector:
-    app: jetson-exporter
+    app: wes-jetson-exporter
   ports:
     - name: http
       protocol: TCP
       port: 9101
       targetPort: http
-  type: ClusterIP
+  type: NodePort
   externalTrafficPolicy: Local
   internalTrafficPolicy: Local
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: jetson-exporter
+  name: wes-jetson-exporter
   labels:
-    app.kubernetes.io/name: jetson-exporter
-    app.kubernetes.io/version: 0.0.2
+    app: wes-jetson-exporter
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: jetson-exporter
+      app: wes-jetson-exporter
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: jetson-exporter
-        app.kubernetes.io/version: 0.0.2
-        app: jetson-exporter
+        app: wes-jetson-exporter
     spec:
       nodeSelector:
         kubernetes.io/arch: "arm64"

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -529,7 +529,7 @@ resources:
   - wes-plugin-network-policy.yaml
   # main components
 #   - cadvisor-exporter.yaml
-#   - jetson-exporter.yaml
+  - jetson-exporter.yaml
 #   - dcgm-exporter.yaml
 #   - nvidia-device-plugin.yaml
   - node-exporter.yaml

--- a/kubernetes/wes-camera-provisioner.yaml
+++ b/kubernetes/wes-camera-provisioner.yaml
@@ -61,7 +61,7 @@ spec:
           hostNetwork: true
           containers:
             - name: wes-camera-provisioner
-              image: waggle/wes-camera-provisioner:0.1.3
+              image: waggle/wes-camera-provisioner:0.1.4
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/kubernetes/wes-plugin-network-policy.yaml
+++ b/kubernetes/wes-plugin-network-policy.yaml
@@ -156,6 +156,7 @@ spec:
       ports:
         - protocol: TCP
           port: 6379
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/kubernetes/wes-plugin-network-policy.yaml
+++ b/kubernetes/wes-plugin-network-policy.yaml
@@ -156,3 +156,21 @@ spec:
       ports:
         - protocol: TCP
           port: 6379
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: wes-plugin-network-policy-jetson-exporter
+spec:
+  podSelector:
+    matchLabels:
+      role: plugin
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: wes-jetson-exporter
+      ports:
+        - protocol: TCP
+          port: 9101

--- a/kubernetes/wes-plugin-scheduler.yaml
+++ b/kubernetes/wes-plugin-scheduler.yaml
@@ -30,7 +30,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: "true"
       containers:
-        - image: waggle/edge-scheduler:0.22.4
+        - image: waggle/edge-scheduler:0.23.0
           imagePullPolicy: IfNotPresent
           name: wes-plugin-scheduler
           command: ["nodescheduler"]


### PR DESCRIPTION
jetson-exporter was designed to be run on all Nvidia Jetson devices and publish GPU utilization metric to local influxDB. It then used a bit more resource for publishing the metrics and logged many warnings and errors regarding the publish, when it failed to publish in time. We have disabled it to reduce the amount of trouble we had on those exporters, i.e. cadvisor-exporter.

We still want to gather GPU metric for analyzing and controlling plugins. Thus, I revised the exporter and use it without the influxDB publishing, until we understand if it is safe to use.

In addition, jetson-exporter will be exposed via wes-jetson-exporter only for local access. This means that any containers in the same Kubernetes node can access to the node's GPU metric via the service. This is to ensure that containers get the metric from the correct GPU, not from other node's GPU.