### PR TITLE
Fix multi manifestv2 cm

### DIFF
--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -673,18 +673,7 @@ restart_bad_meta_init_pods() {
 
 clean_manifestv2_cm() {
     echo "cleaning up waggle-node-manifest-v2 configmaps"
-    pattern="waggle-node-manifest-v2-.*$"
-    # Get a list of configmaps matching the pattern
-    matching_configmaps=$(kubectl get configmaps -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -E "$pattern")
-    # Get the last 3
-    last_configmaps=$(echo "$matching_configmaps" | tail -n 3)
-    # delete except for last 3
-    while IFS= read -r configmap; do
-        if ! echo "$last_configmaps" | grep -q "$configmap"; then
-            echo "Deleting configmap $configmap"
-            kubectl delete configmap "$configmap"
-        fi
-    done <<< "$matching_configmaps"
+    kubectl get cm -o name | grep waggle-node-manifest-v2- | head -n -3 | xargs -r kubectl delete
 }
 
 cd $(dirname $0)

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -671,7 +671,7 @@ restart_bad_meta_init_pods() {
     fi
 }
 
-clean_cm() {
+clean_manifestv2_cm() {
     echo "cleaning up waggle-node-manifest-v2 configmaps"
     pattern="waggle-node-manifest-v2-.*$"
     # Get a list of configmaps matching the pattern
@@ -698,4 +698,4 @@ update_data_config
 update_wes_plugins
 update_wes
 update_influxdb_retention
-clean_cm
+clean_manifestv2_cm


### PR DESCRIPTION
Added a step to clean up manifest v2 config maps. This was added because of ticket [wes-camera-provisioner Out of Memory pod status in W039](https://github.com/waggle-sensor/tickets/issues/182)