### PR TITLE
Refactor pods clean up step

### DIFF
--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -647,31 +647,47 @@ delete_stuck_pods() {
     # 
     # I also clean up kube-system as I've seen cases where coredns or local-path-provisioner
     # are stuck and this prevents other pods from starting.
-    echo "Cleaning up stuck pods."
-    for ns in kube-system default; do
-        echo "cleaning up pods in namespace ${ns}"
-        if kubectl -n "${ns}" get pod | awk 'NR > 1 && !/Running/ && !/Pending/ && !/ContainerCreating/ && !/Terminating/ {print $1}' | timeout 90 xargs -r kubectl -n "${ns}" delete pod; then
-            echo "finished cleaning up pods in namespace ${ns}"
-        else
-            echo "error when cleaning up pods in namespace ${ns}"
-        fi
-    done
-    echo "Done!"
+    echo "cleaning up stuck pods."
+    delete_stuck_pods_ns kube-system
+    delete_stuck_pods_ns default
+    echo "done!"
 
-    # HACK(sean) This is a temporary hack to clean up pods which are stuck in Terminating for a
-    # long time (~1h intervals between when this script is run). It also assumes we don't run this
-    # more often than every minute, in order to allow to 60s termination grace period to finish.
-    #
-    # The plan is to move this and much of the general self healing logic into a node agent.
-    kubectl get pod | awk '/Terminating/ {print $1}' > /tmp/terminating-pods
+    echo "cleaning up stuck terminating pods."
+    delete_stuck_terminating_pods_ns kube-system
+    delete_stuck_terminating_pods_ns default
+    echo "done!"
+}
 
-    if [ -f /tmp/terminating-pods-last ]; then
-        echo "Force cleaning up stuck terminating pods."
-        sort /tmp/terminating-pods /tmp/terminating-pods-last | uniq -d | xargs -r kubectl delete pod --force
-        echo "Done!"
+delete_stuck_pods_ns() {
+    ns="${1}"
+
+    echo "cleaning up pods in namespace ${ns}"
+    if kubectl -n "${ns}" get pod | awk 'NR > 1 && !/Running/ && !/Pending/ && !/ContainerCreating/ && !/Terminating/ {print $1}' | timeout 90 xargs -r kubectl -n "${ns}" delete pod; then
+        echo "finished cleaning up pods in namespace ${ns}"
+    else
+        echo "error when cleaning up pods in namespace ${ns}"
+    fi
+}
+
+# HACK(sean) This is a temporary hack to clean up pods which are stuck in Terminating for a
+# long time (~1h intervals between when this script is run). It also assumes we don't run this
+# more often than every minute, in order to allow to 60s termination grace period to finish.
+#
+# The plan is to move this and much of the general self healing logic into a node agent.
+delete_stuck_terminating_pods_ns() {
+    ns="${1}"
+    f="/tmp/terminating-pods-${ns}"
+    flast="/tmp/terminating-pods-last-${ns}"
+
+    kubectl get pod | awk '/Terminating/ {print $1}' > "${f}"
+
+    if [ -f "${flast}" ]; then
+        echo "force cleaning up stuck terminating pods."
+        sort "${f}" "${flast}" | uniq -d | xargs -r kubectl -n "${ns}" delete pod --force
+        echo "done!"
     fi
 
-    mv /tmp/terminating-pods /tmp/terminating-pods-last
+    mv "${f}" "${flast}"
 }
 
 restart_bad_meta_init_pods() {

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -650,12 +650,12 @@ delete_stuck_pods() {
     echo "cleaning up stuck pods."
     delete_stuck_pods_ns kube-system
     delete_stuck_pods_ns default
-    echo "done!"
+    echo "finished cleaning up stuck pods."
 
     echo "cleaning up stuck terminating pods."
     delete_stuck_terminating_pods_ns kube-system
     delete_stuck_terminating_pods_ns default
-    echo "done!"
+    echo "finished cleaning up stuck terminating pods."
 }
 
 delete_stuck_pods_ns() {
@@ -683,8 +683,11 @@ delete_stuck_terminating_pods_ns() {
 
     if [ -f "${flast}" ]; then
         echo "force cleaning up stuck terminating pods in namespace ${ns}."
-        sort "${f}" "${flast}" | uniq -d | xargs -r kubectl -n "${ns}" delete pod --force
-        echo "done!"
+        if sort "${f}" "${flast}" | uniq -d | xargs -r kubectl -n "${ns}" delete pod --force; then
+            echo "finished force cleaning up stuck terminating pods in namespace ${ns}."
+        else
+            echo "error force cleaning up stuck terminating pods in namespace ${ns}."
+        fi
     fi
 
     mv "${f}" "${flast}"

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -682,7 +682,7 @@ delete_stuck_terminating_pods_ns() {
     kubectl get pod | awk '/Terminating/ {print $1}' > "${f}"
 
     if [ -f "${flast}" ]; then
-        echo "force cleaning up stuck terminating pods."
+        echo "force cleaning up stuck terminating pods in namespace ${ns}."
         sort "${f}" "${flast}" | uniq -d | xargs -r kubectl -n "${ns}" delete pod --force
         echo "done!"
     fi


### PR DESCRIPTION
This PR primarily refactors the pod clean up step but also adds a little more verbose logging and includes applying this to the kube-system namespace in addition to default.