### PR TITLE
Periodic pull and update Lorawan device templates

### DIFF
--- a/kubernetes/wes-chirpstack/wes-chirpstack-server-deployment.yaml
+++ b/kubernetes/wes-chirpstack/wes-chirpstack-server-deployment.yaml
@@ -16,8 +16,8 @@ spec:
         - name: wes-chirpstack-server
           image: waggle/wes-chirpstack-server:0.3.0
           imagePullPolicy: IfNotPresent
-          command: ["chirpstack"]
-          args: ["-c", "/etc/chirpstack-waggle"]
+          command: ["/bin/sh"]
+          args: ["-c", "printenv > /etc/environment && sudo crond -f -d 6 & chirpstack -c /etc/chirpstack-waggle"]
           lifecycle:
             # import the lorawan ttn devices profile templates
             postStart:

--- a/kubernetes/wes-chirpstack/wes-chirpstack-server-deployment.yaml
+++ b/kubernetes/wes-chirpstack/wes-chirpstack-server-deployment.yaml
@@ -14,7 +14,7 @@ spec:
       priorityClassName: wes-high-priority
       containers:
         - name: wes-chirpstack-server
-          image: waggle/wes-chirpstack-server:0.2.0
+          image: waggle/wes-chirpstack-server:0.3.0
           imagePullPolicy: IfNotPresent
           command: ["chirpstack"]
           args: ["-c", "/etc/chirpstack-waggle"]


### PR DESCRIPTION
This PR updates [wes-chirpstack-server to 0.3.0](https://github.com/waggle-sensor/wes-chirpstack-server/releases/tag/0.3.0). This version clones our [LoRaWAN device profile templates](https://github.com/waggle-sensor/wes-lorawan-device-templates) into the Chirpstack server pod, allowing for the LoRaWAN device profile templates to be periodically pulled and imported to Chirpstack's Application Server.