### PR TITLE
update installation margin for Chirpstack's ADR engine 

### DIFF
--- a/kubernetes/wes-chirpstack/region_us915_sub_band_2.toml
+++ b/kubernetes/wes-chirpstack/region_us915_sub_band_2.toml
@@ -18,3 +18,12 @@ password="$MQTT_BROKER_PASSWORD"
 #   This is using Sub band 2 for more channels see, 
 #   https://www.baranidesign.com/faq-articles/2019/4/23/lorawan-usa-frequencies-channels-and-sub-bands-for-iot-devices
 enabled_uplink_channels=[8,9,10,11,12,13,14,15] 
+# Installation margin (dB) used by the ADR engine (default is 10).
+#
+# A higher number means that the network-server will keep more margin,
+# resulting in a lower data-rate (higher Spreading Factor) but decreasing the chance that the
+# device gets disconnected because it is unable to reach one of the surrounded gateways.
+# SUMMARY:
+# - Higher values (>=10 dB) → More conservative, longer range, lower data rates, chance of disconnection is reduced, lora sensor battery life is reduced
+# - Lower values (5-8 dB) → More aggressive, better network efficiency, riskier in weak signal areas, faster data transmission, Less airtime usage, more risk of disconnection, lora sensor battery life is increased
+installation_margin=15


### PR DESCRIPTION
This pull request includes a change to the `kubernetes/wes-chirpstack/region_us915_sub_band_2.toml` file, which adds a new configuration parameter for the installation margin used by Chirpstack's ADR engine.

Configuration updates:

* [`kubernetes/wes-chirpstack/region_us915_sub_band_2.toml`](diffhunk://#diff-42bd81c1e85b1514a9d4b650f74c4528c1b4fb295dc01958c4eb82916a038612R21-R29): Added `installation_margin` parameter with a value of 15 dB, providing a detailed explanation of its impact on network performance and device behavior.