### PR TITLE
Upped scheduler version

### DIFF
--- a/kubernetes/wes-plugin-scheduler.yaml
+++ b/kubernetes/wes-plugin-scheduler.yaml
@@ -30,7 +30,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: "true"
       containers:
-        - image: waggle/edge-scheduler:0.27.2
+        - image: waggle/edge-scheduler:0.27.5
           imagePullPolicy: IfNotPresent
           name: wes-plugin-scheduler
           command: ["nodescheduler"]


### PR DESCRIPTION
The new scheduler is improved with an active garbage collector that cleans up dangling Pods in case the scheduler misses the Kubernetes event on Pod's termination. While we do not exactly know why, although we suspect Kubernetes did not send the event under some pressure, this collector ensures that terminated Pods are eventually removed.