### PR TITLE
Chirpstack metrics

### DIFF
--- a/kubernetes/wes-metrics-agent.yaml
+++ b/kubernetes/wes-metrics-agent.yaml
@@ -16,8 +16,10 @@ spec:
       priorityClassName: wes-high-priority
       containers:
         - name: wes-metrics-agent
-          image: waggle/wes-metrics-agent:pr-16
-          imagePullPolicy: Always #IfNotPresent
+          image: waggle/wes-metrics-agent:pr-16 #TODO: change to latest version, when done testing
+          imagePullPolicy: Always #IfNotPresent TODO: change to IfNotPresent, when done testing
+          command: ["python", "main.py"]  #TODO: remove, when done testing
+          args: ["--debug"]  #TODO: remove, when done testing
           securityContext:
             privileged: true
           resources:

--- a/kubernetes/wes-metrics-agent.yaml
+++ b/kubernetes/wes-metrics-agent.yaml
@@ -17,9 +17,7 @@ spec:
       containers:
         - name: wes-metrics-agent
           image: waggle/wes-metrics-agent:pr-16 #TODO: change to latest version, when done testing
-          imagePullPolicy: Always #IfNotPresent TODO: change to IfNotPresent, when done testing
-          command: ["python", "main.py"]  #TODO: remove, when done testing
-          args: ["--debug"]  #TODO: remove, when done testing
+          imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
           resources:

--- a/kubernetes/wes-metrics-agent.yaml
+++ b/kubernetes/wes-metrics-agent.yaml
@@ -45,6 +45,10 @@ spec:
               value: service
             - name: METRICS_URL
               value: "http://$(HOST_IP):9100/metrics"
+            - name: CHIRPSTACK_METRICS_URL
+              value: "http://wes-chirpstack-server:9100/metrics"
+            - name: CHIRPSTACK_GATEWAY_METRICS_URL
+              value: "http://wes-chirpstack-gateway-bridge:9100/metrics"
             - name: RABBITMQ_EXCHANGE
               value: "to-beehive"
             - name: GPSD_HOST

--- a/kubernetes/wes-metrics-agent.yaml
+++ b/kubernetes/wes-metrics-agent.yaml
@@ -35,6 +35,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: RESOURCE_LORAWAN
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['resource.lorawan']
             - name: RABBITMQ_HOST
               value: "wes-rabbitmq"
             - name: RABBITMQ_PORT

--- a/kubernetes/wes-metrics-agent.yaml
+++ b/kubernetes/wes-metrics-agent.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: wes-metrics-agent
           image: waggle/wes-metrics-agent:pr-16
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always #IfNotPresent
           securityContext:
             privileged: true
           resources:

--- a/kubernetes/wes-metrics-agent.yaml
+++ b/kubernetes/wes-metrics-agent.yaml
@@ -16,7 +16,7 @@ spec:
       priorityClassName: wes-high-priority
       containers:
         - name: wes-metrics-agent
-          image: waggle/wes-metrics-agent:0.8.2
+          image: waggle/wes-metrics-agent:pr-16
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/kubernetes/wes-metrics-agent.yaml
+++ b/kubernetes/wes-metrics-agent.yaml
@@ -35,10 +35,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-            - name: RESOURCE_LORAWAN
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['resource.lorawan']
             - name: RABBITMQ_HOST
               value: "wes-rabbitmq"
             - name: RABBITMQ_PORT


### PR DESCRIPTION
This pull request includes updates to the `kubernetes/wes-metrics-agent.yaml` file to modify the image version and add new environment variables for metrics URLs. These additions will add the ability to collect chirpstack prometheus metrics.

Updates to `kubernetes/wes-metrics-agent.yaml`:

* Changed the `image` field for the `wes-metrics-agent` container to use the newest version.
   * These are the additions made to `wes-metrics-agent`: https://github.com/waggle-sensor/wes-metrics-agent/pull/16
* Added new environment variables `CHIRPSTACK_METRICS_URL` and `CHIRPSTACK_GATEWAY_METRICS_URL` to specify the URLs for ChirpStack server and gateway metrics.