### PR TITLE
Lorawan metrics

### DIFF
--- a/kubernetes/wes-metrics-agent.yaml
+++ b/kubernetes/wes-metrics-agent.yaml
@@ -45,6 +45,10 @@ spec:
               value: service
             - name: METRICS_URL
               value: "http://$(HOST_IP):9100/metrics"
+            - name: CHIRPSTACK_METRICS_URL
+              value: "http://wes-chirpstack-server:9100/metrics"
+            - name: CHIRPSTACK_GATEWAY_METRICS_URL
+              value: "http://wes-chirpstack-gateway-bridge:9100/metrics"
             - name: RABBITMQ_EXCHANGE
               value: "to-beehive"
             - name: GPSD_HOST

--- a/kubernetes/wes-metrics-agent.yaml
+++ b/kubernetes/wes-metrics-agent.yaml
@@ -16,7 +16,7 @@ spec:
       priorityClassName: wes-high-priority
       containers:
         - name: wes-metrics-agent
-          image: waggle/wes-metrics-agent:0.8.2
+          image: waggle/wes-metrics-agent:0.8.3
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true


### PR DESCRIPTION
This pull request includes updates to the kubernetes/wes-metrics-agent.yaml file to modify the image version and add new environment variables for metrics URLs. These additions will add the ability to collect chirpstack prometheus metrics.

Updates to `kubernetes/wes-metrics-agent.yaml`:

* Upgraded the `wes-metrics-agent` image from version `0.8.2` to `0.8.3` to ensure the latest features.
   * These are the additions made to `wes-metrics-agent`: https://github.com/waggle-sensor/wes-metrics-agent/pull/16 
* Added two new environment variables: `CHIRPSTACK_METRICS_URL` and `CHIRPSTACK_GATEWAY_METRICS_URL` to provide additional metrics endpoints for monitoring.