### PR TITLE
Upgrade RMQ to 3.13

### DIFF
--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -431,12 +431,17 @@ update_rabbitmq_version() {
     # Verify feature flags are enabled
     echo "Verifying feature flags..."
     kubectl exec wes-rabbitmq-0 -- rabbitmqctl -q --formatter pretty_table list_feature_flags || true
+    echo "DEBUG: Feature flags verification completed"
     
     # Determine upgrade path
     echo "Determining upgrade path..."
+    echo "DEBUG: About to call determine_rabbitmq_upgrade_path with current_ver=$current_ver, target_ver=$target_ver"
     upgrade_path=$(determine_rabbitmq_upgrade_path "$current_ver" "$target_ver")
+    echo "DEBUG: determine_rabbitmq_upgrade_path returned: $upgrade_path"
     
-    if [ $? -ne 0 ]; then
+    local exit_code=$?
+    echo "DEBUG: determine_rabbitmq_upgrade_path exit code: $exit_code"
+    if [ $exit_code -ne 0 ]; then
         echo "Error: No supported upgrade path found from $current_ver to $target_ver"
         waggle_log err "No supported RabbitMQ upgrade path found: $current_ver -> $target_ver"
         return 1

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -486,6 +486,9 @@ log.console = true
 # mqtt config for lorawan
 mqtt.default_user = service
 mqtt.default_pass = service
+
+# enable deprecated features for management metrics collection
+deprecated_features.permit.management_metrics_collection = true
 EOF
 
     WAGGLE_BEEHIVE_RABBITMQ_HOST=$(get_configmap_field waggle-config WAGGLE_BEEHIVE_RABBITMQ_HOST)

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -437,8 +437,15 @@ update_rabbitmq_version() {
     # Determine upgrade path
     echo "Determining upgrade path..."
     echo "DEBUG: About to call determine_rabbitmq_upgrade_path with current_ver=$current_ver, target_ver=$target_ver"
-    upgrade_path=$(determine_rabbitmq_upgrade_path "$current_ver" "$target_ver")
-    echo "DEBUG: determine_rabbitmq_upgrade_path returned: $upgrade_path"
+    echo "DEBUG: Testing if function exists..."
+    if declare -f determine_rabbitmq_upgrade_path > /dev/null; then
+        echo "DEBUG: Function exists, calling it..."
+        upgrade_path=$(determine_rabbitmq_upgrade_path "$current_ver" "$target_ver")
+        echo "DEBUG: determine_rabbitmq_upgrade_path returned: $upgrade_path"
+    else
+        echo "DEBUG: Function does not exist!"
+        return 1
+    fi
     
     local exit_code=$?
     echo "DEBUG: determine_rabbitmq_upgrade_path exit code: $exit_code"

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -584,6 +584,20 @@ EOF
             "durable": true,
             "auto_delete": false,
             "arguments": {}
+        },
+        {
+            "name": "ansible",
+            "vhost": "/",
+            "durable": true,
+            "auto_delete": false,
+            "arguments": {}
+        },
+        {
+            "name": "to-validator",
+            "vhost": "/",
+            "durable": true,
+            "auto_delete": false,
+            "arguments": {}
         }
     ],
     "exchanges": [
@@ -616,6 +630,15 @@ EOF
         },
         {
             "name": "to-node",
+            "vhost": "/",
+            "type": "topic",
+            "durable": true,
+            "auto_delete": false,
+            "internal": false,
+            "arguments": {}
+        },
+        {
+            "name": "to-validator",
             "vhost": "/",
             "type": "topic",
             "durable": true,

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -187,6 +187,7 @@ update_wes_plugins() {
 # determine_rabbitmq_upgrade_path: Determines the upgrade path between two RabbitMQ versions
 # Returns a space-separated list of intermediate versions, or empty string if direct upgrade
 determine_rabbitmq_upgrade_path() {
+    echo "DEBUG: ENTERING determine_rabbitmq_upgrade_path function"
     local current_ver="$1"
     local target_ver="$2"
     

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -239,7 +239,7 @@ determine_rabbitmq_upgrade_path() {
         local intermediate_versions=""
         local current_step="$current_pattern"
         
-        while [ -n "$current_step" ] && [ "$current_step" != "$target_pattern" ]; do
+        while [ -n "$current_step" ]; do
             local next_step="${supported_paths[$current_step]}"
             if [ -n "$next_step" ]; then
                 # Convert pattern to major.minor version for intermediate step
@@ -261,6 +261,8 @@ determine_rabbitmq_upgrade_path() {
                 
                 # Check if we've reached the target pattern
                 if [[ "$target_ver" =~ ^${next_step//x/} ]]; then
+                    # We've found the target pattern, stop here
+                    # Don't add this step to intermediate versions since it's the target
                     break
                 fi
                 

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -397,42 +397,42 @@ update_rabbitmq_version() {
         echo "Will upgrade through intermediate versions: $upgrade_path"
         waggle_log info "RabbitMQ will upgrade through intermediate versions: $upgrade_path"
         
-        # # Upgrade through intermediate versions
-        # for version in $upgrade_path; do
-        #     if ! upgrade_rabbitmq_to_version "$version"; then
-        #         echo "Error: Failed to upgrade to intermediate version $version"
-        #         return 1
-        #     fi
-        # done
+        # Upgrade through intermediate versions
+        for version in $upgrade_path; do
+            if ! upgrade_rabbitmq_to_version "$version"; then
+                echo "Error: Failed to upgrade to intermediate version $version"
+                return 1
+            fi
+        done
     else
         echo "Direct upgrade path available"
         waggle_log info "RabbitMQ direct upgrade path available"
     fi
     
     # Finally upgrade to target version
-    # if ! upgrade_rabbitmq_to_version "$target_ver"; then
-    #     echo "Error: Failed to upgrade to target version $target_ver"
-    #     return 1
-    # fi
+    if ! upgrade_rabbitmq_to_version "$target_ver"; then
+        echo "Error: Failed to upgrade to target version $target_ver"
+        return 1
+    fi
     
     # Verify the upgrade was successful
-    # echo "Verifying upgrade was successful..."
-    # if ! new_version=$(kubectl get statefulset wes-rabbitmq -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null); then
-    #     echo "Warning: Could not verify new version"
-    #     waggle_log warn "Could not verify RabbitMQ new version"
-    # else
-    #     new_ver=$(echo "$new_version" | sed 's/rabbitmq://' | sed 's/-management-alpine//')
-    #     if [ "$new_ver" = "$target_ver" ]; then
-    #         echo "Upgrade verification successful: RabbitMQ is now running version $new_ver"
-    #         waggle_log info "RabbitMQ upgrade verification successful: now running version $new_ver"
-    #     else
-    #         echo "Warning: Upgrade verification failed. Expected: $target_ver, Got: $new_ver"
-    #         waggle_log warn "RabbitMQ upgrade verification failed. Expected: $target_ver, Got: $new_ver"
-    #     fi
-    # fi
+    echo "Verifying upgrade was successful..."
+    if ! new_version=$(kubectl get statefulset wes-rabbitmq -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null); then
+        echo "Warning: Could not verify new version"
+        waggle_log warn "Could not verify RabbitMQ new version"
+    else
+        new_ver=$(echo "$new_version" | sed 's/rabbitmq://' | sed 's/-management-alpine//')
+        if [ "$new_ver" = "$target_ver" ]; then
+            echo "Upgrade verification successful: RabbitMQ is now running version $new_ver"
+            waggle_log info "RabbitMQ upgrade verification successful: now running version $new_ver"
+        else
+            echo "Warning: Upgrade verification failed. Expected: $target_ver, Got: $new_ver"
+            waggle_log warn "RabbitMQ upgrade verification failed. Expected: $target_ver, Got: $new_ver"
+        fi
+    fi
     
-    # echo "RabbitMQ version upgrade completed successfully"
-    # waggle_log info "RabbitMQ version upgrade completed successfully: $current_ver -> $target_ver"
+    echo "RabbitMQ version upgrade completed successfully"
+    waggle_log info "RabbitMQ version upgrade completed successfully: $current_ver -> $target_ver"
 }
 
 update_wes() {

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -224,8 +224,6 @@ determine_rabbitmq_upgrade_path() {
         current_pattern="4.0.x"
     fi
     
-
-    
     # Check if direct upgrade is supported
     if [ -n "$current_pattern" ] && [ -n "${supported_paths[$current_pattern]}" ]; then
         local target_pattern="${supported_paths[$current_pattern]}"
@@ -245,11 +243,14 @@ determine_rabbitmq_upgrade_path() {
             local next_step="${supported_paths[$current_step]}"
             if [ -n "$next_step" ]; then
                 # Check if we've reached the target pattern BEFORE adding to intermediate versions
+                echo "DEBUG: Checking if target_ver=$target_ver matches next_step=$next_step (pattern: ^${next_step//x/})"
                 if [[ "$target_ver" =~ ^${next_step//x/} ]]; then
+                    echo "DEBUG: Target pattern matched! Breaking without adding $next_step"
                     # We've found the target pattern, stop here
                     # Don't add this step to intermediate versions since it's the target
                     break
                 fi
+                echo "DEBUG: Target pattern did not match, will add $next_step to intermediate versions"
                 
                 # Convert pattern to major.minor version for intermediate step
                 if [[ "$next_step" =~ ^3\. ]]; then

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -243,14 +243,11 @@ determine_rabbitmq_upgrade_path() {
             local next_step="${supported_paths[$current_step]}"
             if [ -n "$next_step" ]; then
                 # Check if we've reached the target pattern BEFORE adding to intermediate versions
-                echo "DEBUG: Checking if target_ver=$target_ver matches next_step=$next_step (pattern: ^${next_step//x/})"
                 if [[ "$target_ver" =~ ^${next_step//x/} ]]; then
-                    echo "DEBUG: Target pattern matched! Breaking without adding $next_step"
                     # We've found the target pattern, stop here
                     # Don't add this step to intermediate versions since it's the target
                     break
                 fi
-                echo "DEBUG: Target pattern did not match, will add $next_step to intermediate versions"
                 
                 # Convert pattern to major.minor version for intermediate step
                 if [[ "$next_step" =~ ^3\. ]]; then

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -299,13 +299,14 @@ upgrade_rabbitmq_to_version() {
     
     # Wait for RabbitMQ to be running
     echo "Waiting for RabbitMQ to be running after $target_ver upgrade..."
-    if ! kubectl wait --for=condition=running pod/wes-rabbitmq-0 --timeout=600s; then
-        echo "Error: RabbitMQ not running after $target_ver upgrade"
-        waggle_log err "RabbitMQ not running after $target_ver upgrade"
+    if ! kubectl wait --for=condition=Ready pod/wes-rabbitmq-0 --timeout=600s; then
+        echo "Error: RabbitMQ not ready after $target_ver upgrade"
+        waggle_log err "RabbitMQ not ready after $target_ver upgrade"
         return 1
     fi
     
     # Enable feature flags for next upgrade
+    sleep 1m
     echo "Enabling feature flags for next upgrade..."
     kubectl exec wes-rabbitmq-0 -- rabbitmqctl enable_feature_flag all || true
     

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -443,6 +443,8 @@ update_rabbitmq_version() {
         echo "DEBUG: Function definition:"
         declare -f determine_rabbitmq_upgrade_path
         echo "DEBUG: Now calling the function..."
+        echo "DEBUG: Calling function directly..."
+        determine_rabbitmq_upgrade_path "$current_ver" "$target_ver"
         upgrade_path=$(determine_rabbitmq_upgrade_path "$current_ver" "$target_ver")
         echo "DEBUG: determine_rabbitmq_upgrade_path returned: $upgrade_path"
     else

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -267,7 +267,7 @@ upgrade_rabbitmq_to_version() {
     fi
     
     # Enable feature flags for next upgrade
-    sleep 1m
+    sleep 3m
     echo "Enabling feature flags for next upgrade..."
     kubectl exec wes-rabbitmq-0 -- rabbitmqctl enable_feature_flag all || true
     

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -297,11 +297,11 @@ upgrade_rabbitmq_to_version() {
         return 1
     fi
     
-    # Wait for RabbitMQ to be ready
-    echo "Waiting for RabbitMQ to be ready after $target_ver upgrade..."
-    if ! kubectl wait --for=condition=ready pod/wes-rabbitmq-0 --timeout=300s; then
-        echo "Error: RabbitMQ not ready after $target_ver upgrade"
-        waggle_log err "RabbitMQ not ready after $target_ver upgrade"
+    # Wait for RabbitMQ to be running
+    echo "Waiting for RabbitMQ to be running after $target_ver upgrade..."
+    if ! kubectl wait --for=condition=running pod/wes-rabbitmq-0 --timeout=600s; then
+        echo "Error: RabbitMQ not running after $target_ver upgrade"
+        waggle_log err "RabbitMQ not running after $target_ver upgrade"
         return 1
     fi
     

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -440,6 +440,9 @@ update_rabbitmq_version() {
     echo "DEBUG: Testing if function exists..."
     if declare -f determine_rabbitmq_upgrade_path > /dev/null; then
         echo "DEBUG: Function exists, calling it..."
+        echo "DEBUG: Function definition:"
+        declare -f determine_rabbitmq_upgrade_path
+        echo "DEBUG: Now calling the function..."
         upgrade_path=$(determine_rabbitmq_upgrade_path "$current_ver" "$target_ver")
         echo "DEBUG: determine_rabbitmq_upgrade_path returned: $upgrade_path"
     else

--- a/kubernetes/update-stack.sh
+++ b/kubernetes/update-stack.sh
@@ -699,6 +699,14 @@ EOF
             "destination_type": "queue",
             "routing_key": "*.ansible",
             "arguments": {}
+        },
+        {
+            "source": "to-validator",
+            "vhost": "/",
+            "destination": "to-validator",
+            "destination_type": "queue",
+            "routing_key": "*.to-validator",
+            "arguments": {}
         }
     ],
     "parameters": [

--- a/kubernetes/wes-rabbitmq.yaml
+++ b/kubernetes/wes-rabbitmq.yaml
@@ -39,7 +39,7 @@ spec:
         node-role.kubernetes.io/master: "true"
       containers:
         - name: wes-rabbitmq
-          image: rabbitmq:3.8.11-management-alpine
+          image: rabbitmq:3.13.7-management-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:


### PR DESCRIPTION
This pull request introduces an automated RabbitMQ upgrade process to the `kubernetes/update-stack.sh` script, along with updates to the RabbitMQ configuration and Kubernetes manifest. The main focus is on safely upgrading RabbitMQ through supported intermediate versions, ensuring data backup, feature flag management, and comprehensive health checks and logging. Additionally, new queues, exchanges, and bindings are added to the RabbitMQ configuration, and the target RabbitMQ version is bumped in the deployment manifest.

**RabbitMQ Upgrade Automation and Safety**

* Added `update_rabbitmq_version`, `determine_rabbitmq_upgrade_path`, and `upgrade_rabbitmq_to_version` functions to automate RabbitMQ upgrades, handling intermediate versions, data backup, feature flag enabling, health checks, and logging. These functions ensure upgrades follow official supported paths and prevent downgrades. (`kubernetes/update-stack.sh`)
* Integrated the new upgrade function into the main update workflow to ensure RabbitMQ is upgraded as part of the stack update process. (`kubernetes/update-stack.sh`)
* Updated the RabbitMQ image version in the Kubernetes manifest from `3.8.11-management-alpine` to `3.13.7-management-alpine`, aligning with the upgrade logic. (`kubernetes/wes-rabbitmq.yaml`)

**RabbitMQ Configuration Enhancements**

* Added new queues (`ansible`, `to-validator`), exchanges (`to-validator`), and bindings for improved message routing and integration with validator and ansible components. (`kubernetes/update-stack.sh`) [[1]](diffhunk://#diff-e06ca7ce7b008c0a52f85ea2e5fde0216d89a08a8815ff487e2ce717e5528510R591-R604) [[2]](diffhunk://#diff-e06ca7ce7b008c0a52f85ea2e5fde0216d89a08a8815ff487e2ce717e5528510R643-R651) [[3]](diffhunk://#diff-e06ca7ce7b008c0a52f85ea2e5fde0216d89a08a8815ff487e2ce717e5528510R686-R693)
* Enabled deprecated RabbitMQ management metrics collection for compatibility with monitoring tools. (`kubernetes/update-stack.sh`)